### PR TITLE
feat: add Claude Code plugin with Neon MCP Server

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,21 @@
+{
+  "name": "neon-agent-skills",
+  "owner": {
+    "name": "Andre Landgraf",
+    "email": "andre@neon.tech"
+  },
+  "metadata": {
+    "description": "Official Neon agent skills for Claude Code",
+    "version": "1.0.0"
+  },
+  "plugins": [
+    {
+      "name": "using-neon",
+      "source": "./",
+      "description": "Neon Serverless Postgres integration - skills and MCP server",
+      "version": "1.0.0",
+      "category": "database",
+      "tags": ["postgres", "serverless", "database", "mcp", "neon"]
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,15 @@
+{
+  "name": "neon",
+  "version": "1.0.0",
+  "description": "Neon Serverless Postgres integration for Claude Code. Includes guides for Neon development and the Neon MCP Server for natural language database management.",
+  "author": {
+    "name": "Neon",
+    "url": "https://neon.tech"
+  },
+  "homepage": "https://neon.tech/docs/ai/neon-mcp-server",
+  "repository": "https://github.com/neondatabase/agent-skills",
+  "license": "Apache-2.0",
+  "keywords": ["neon", "postgres", "serverless", "database", "mcp"],
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.json"
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "neon": {
+      "type": "http",
+      "url": "https://mcp.neon.tech/mcp"
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -51,6 +51,17 @@ A comprehensive guide and best practices for working with Neon Serverless Postgr
 npx add-skill neondatabase/agent-skills
 ```
 
+### Claude Code Plugin
+
+You can also install the skills as a Claude Code plugin, which bundles both the skills and the [Neon MCP Server](https://mcp.neon.tech) for natural language database management:
+
+```
+/plugin marketplace add neondatabase/agent-skills
+/plugin install using-neon@neon-agent-skills
+```
+
+After installation, you'll be prompted to authenticate with Neon via OAuth when you first use MCP tools.
+
 ## Usage
 
 Example prompts:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,24 @@
 {
   "name": "@neondatabase/agent-skills",
+  "version": "1.0.0",
   "description": "A collection of Agent Skills for Neon Serverless Postgres",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/neondatabase/agent-skills"
+  },
+  "author": {
+    "name": "Neon",
+    "url": "https://neon.tech"
+  },
+  "keywords": [
+    "neon",
+    "postgres",
+    "serverless",
+    "agent-skills",
+    "claude-code",
+    "mcp"
+  ],
   "scripts": {
     "fmt": "npx prettier --write ."
   }


### PR DESCRIPTION
- Add .claude-plugin/plugin.json manifest for Claude Code plugin
- Add .claude-plugin/marketplace.json for plugin discovery
- Add .mcp.json to bundle Neon MCP Server (OAuth-based remote server)
- Update package.json with version and metadata
- Update README.md with Claude Code plugin installation instructions

Users can now install via Claude Code:
  /plugin marketplace add neondatabase/agent-skills /plugin install neon@neon-plugins

This bundles both the using-neon skill and the Neon MCP Server for natural language database management.