### PR TITLE
fix: update neon.tech URLs to neon.com

### DIFF
--- a/skills/neon-postgres/SKILL.md
+++ b/skills/neon-postgres/SKILL.md
@@ -19,10 +19,10 @@ You can use the `curl` commands to fetch the documentation page as markdown:
 
 ```bash
 # Get list of all Neon docs
-curl https://neon.tech/llms.txt
+curl https://neon.com/llms.txt
 
 # Fetch any doc page as markdown
-curl -H "Accept: text/markdown" https://neon.tech/docs/<path>
+curl -H "Accept: text/markdown" https://neon.com/docs/<path>
 ```
 
 Don't guess docs pages. Use the `llms.txt` index to find the relevant URL or follow the links in the resources below.

--- a/skills/neon-postgres/references/connection-methods.md
+++ b/skills/neon-postgres/references/connection-methods.md
@@ -5,7 +5,7 @@ Guide to selecting the optimal connection method for your Neon Postgres database
 For official documentation:
 
 ```bash
-curl -H "Accept: text/markdown" https://neon.tech/docs/connect/choose-connection
+curl -H "Accept: text/markdown" https://neon.com/docs/connect/choose-connection
 ```
 
 ## Decision Tree
@@ -20,14 +20,14 @@ For non-TypeScript languages, connect from a secure backend server using your la
 
 | Language/Framework  | Documentation                               |
 | ------------------- | ------------------------------------------- |
-| Django (Python)     | https://neon.tech/docs/guides/django        |
-| SQLAlchemy (Python) | https://neon.tech/docs/guides/sqlalchemy    |
-| Elixir Ecto         | https://neon.tech/docs/guides/elixir-ecto   |
-| Laravel (PHP)       | https://neon.tech/docs/guides/laravel       |
-| Ruby on Rails       | https://neon.tech/docs/guides/ruby-on-rails |
-| Go                  | https://neon.tech/docs/guides/go            |
-| Rust                | https://neon.tech/docs/guides/rust          |
-| Java                | https://neon.tech/docs/guides/java          |
+| Django (Python)     | https://neon.com/docs/guides/django        |
+| SQLAlchemy (Python) | https://neon.com/docs/guides/sqlalchemy    |
+| Elixir Ecto         | https://neon.com/docs/guides/elixir-ecto   |
+| Laravel (PHP)       | https://neon.com/docs/guides/laravel       |
+| Ruby on Rails       | https://neon.com/docs/guides/ruby-on-rails |
+| Go                  | https://neon.com/docs/guides/go            |
+| Rust                | https://neon.com/docs/guides/rust          |
+| Java                | https://neon.com/docs/guides/java          |
 
 **TypeScript/JavaScript** → Continue to step 2.
 
@@ -40,7 +40,7 @@ For non-TypeScript languages, connect from a secure backend server using your la
 This is the only option for client-side apps since browsers cannot make direct TCP connections to Postgres. See `neon-js.md` for setup.
 
 ```bash
-curl -H "Accept: text/markdown" https://neon.tech/docs/reference/javascript-sdk
+curl -H "Accept: text/markdown" https://neon.com/docs/reference/javascript-sdk
 ```
 
 **No** → Continue to step 3.
@@ -78,7 +78,7 @@ WebSocket maintains connection state needed for transactions. See `neon-serverle
 HTTP is faster for single queries (~3 roundtrips vs ~8 for TCP). See `neon-serverless.md` for setup.
 
 ```bash
-curl -H "Accept: text/markdown" https://neon.tech/docs/serverless/serverless-driver
+curl -H "Accept: text/markdown" https://neon.com/docs/serverless/serverless-driver
 ```
 
 ---
@@ -90,14 +90,14 @@ curl -H "Accept: text/markdown" https://neon.tech/docs/serverless/serverless-dri
 Vercel's Fluid compute supports connection pooling. Use `attachDatabasePool` for optimal connection management.
 
 ```bash
-curl -H "Accept: text/markdown" https://neon.tech/docs/guides/vercel-connection-methods
+curl -H "Accept: text/markdown" https://neon.com/docs/guides/vercel-connection-methods
 ```
 
 **Cloudflare (with Hyperdrive)** → Use **TCP via Hyperdrive**
 
 Cloudflare Hyperdrive provides connection pooling for Workers. Use `node-postgres` or any native TCP driver.
 
-See https://neon.tech/docs/guides/cloudflare-hyperdrive for more on connecting with Cloudflare Workers and Hyperdrive.
+See https://neon.com/docs/guides/cloudflare-hyperdrive for more on connecting with Cloudflare Workers and Hyperdrive.
 
 **No pooling support (Netlify, Deno Deploy)** → Use `@neondatabase/serverless`
 
@@ -125,10 +125,10 @@ Popular TypeScript/JavaScript ORMs all work with Neon:
 
 | ORM     | Drivers Supported                               | Documentation                         |
 | ------- | ----------------------------------------------- | ------------------------------------- |
-| Drizzle | `pg`, `postgres.js`, `@neondatabase/serverless` | https://neon.tech/docs/guides/drizzle |
-| Kysely  | `pg`, `postgres.js`, `@neondatabase/serverless` | https://neon.tech/docs/guides/kysely  |
-| Prisma  | `pg`, `@neondatabase/serverless`                | https://neon.tech/docs/guides/prisma  |
-| TypeORM | `pg`                                            | https://neon.tech/docs/guides/typeorm |
+| Drizzle | `pg`, `postgres.js`, `@neondatabase/serverless` | https://neon.com/docs/guides/drizzle |
+| Kysely  | `pg`, `postgres.js`, `@neondatabase/serverless` | https://neon.com/docs/guides/kysely  |
+| Prisma  | `pg`, `@neondatabase/serverless`                | https://neon.com/docs/guides/prisma  |
+| TypeORM | `pg`                                            | https://neon.com/docs/guides/typeorm |
 
 All ORMs support both TCP drivers and Neon's serverless driver depending on your platform.
 
@@ -186,8 +186,8 @@ Then provide:
 
 | Topic                      | URL                                                     |
 | -------------------------- | ------------------------------------------------------- |
-| Choosing Connection Method | https://neon.tech/docs/connect/choose-connection        |
-| Serverless Driver          | https://neon.tech/docs/serverless/serverless-driver     |
-| JavaScript SDK             | https://neon.tech/docs/reference/javascript-sdk         |
-| Connection Pooling         | https://neon.tech/docs/connect/connection-pooling       |
-| Vercel Connection Methods  | https://neon.tech/docs/guides/vercel-connection-methods |
+| Choosing Connection Method | https://neon.com/docs/connect/choose-connection        |
+| Serverless Driver          | https://neon.com/docs/serverless/serverless-driver     |
+| JavaScript SDK             | https://neon.com/docs/reference/javascript-sdk         |
+| Connection Pooling         | https://neon.com/docs/connect/connection-pooling       |
+| Vercel Connection Methods  | https://neon.com/docs/guides/vercel-connection-methods |

--- a/skills/neon-postgres/references/devtools.md
+++ b/skills/neon-postgres/references/devtools.md
@@ -19,7 +19,7 @@ This command:
 For full CLI reference:
 
 ```bash
-curl -H "Accept: text/markdown" https://neon.tech/docs/reference/cli-init
+curl -H "Accept: text/markdown" https://neon.com/docs/reference/cli-init
 ```
 
 ## VSCode Extension
@@ -46,7 +46,7 @@ code --install-extension neon.neon-vscode
 For detailed documentation:
 
 ```bash
-curl -H "Accept: text/markdown" https://neon.tech/docs/local/vscode-extension
+curl -H "Accept: text/markdown" https://neon.com/docs/local/vscode-extension
 ```
 
 ## Neon MCP Server
@@ -108,14 +108,14 @@ Get your API key from: https://console.neon.tech/app/settings/api-keys
 For full MCP server documentation:
 
 ```bash
-curl -H "Accept: text/markdown" https://neon.tech/docs/ai/neon-mcp-server
+curl -H "Accept: text/markdown" https://neon.com/docs/ai/neon-mcp-server
 ```
 
 ## Documentation Resources
 
 | Topic              | URL                                           |
 | ------------------ | --------------------------------------------- |
-| CLI Init Command   | https://neon.tech/docs/reference/cli-init     |
-| VSCode Extension   | https://neon.tech/docs/local/vscode-extension |
-| MCP Server         | https://neon.tech/docs/ai/neon-mcp-server     |
-| Neon CLI Reference | https://neon.tech/docs/reference/neon-cli     |
+| CLI Init Command   | https://neon.com/docs/reference/cli-init     |
+| VSCode Extension   | https://neon.com/docs/local/vscode-extension |
+| MCP Server         | https://neon.com/docs/ai/neon-mcp-server     |
+| Neon CLI Reference | https://neon.com/docs/reference/neon-cli     |

--- a/skills/neon-postgres/references/features.md
+++ b/skills/neon-postgres/references/features.md
@@ -7,7 +7,7 @@ Overview of Neon's key platform features. For detailed information, fetch the of
 Create instant, copy-on-write clones of your database at any point in time. Branches are isolated environments perfect for development, testing, and preview deployments.
 
 ```bash
-curl -H "Accept: text/markdown" https://neon.tech/docs/introduction/branching
+curl -H "Accept: text/markdown" https://neon.com/docs/introduction/branching
 ```
 
 **Key Points:**
@@ -33,7 +33,7 @@ If the Neon MCP server is available, you can use it to list and create branches.
 Neon automatically scales compute resources based on workload demand.
 
 ```bash
-curl -H "Accept: text/markdown" https://neon.tech/docs/introduction/autoscaling
+curl -H "Accept: text/markdown" https://neon.com/docs/introduction/autoscaling
 ```
 
 **Key Points:**
@@ -48,7 +48,7 @@ curl -H "Accept: text/markdown" https://neon.tech/docs/introduction/autoscaling
 Databases automatically suspend after a period of inactivity, reducing costs to storage-only.
 
 ```bash
-curl -H "Accept: text/markdown" https://neon.tech/docs/introduction/scale-to-zero
+curl -H "Accept: text/markdown" https://neon.com/docs/introduction/scale-to-zero
 ```
 
 **Key Points:**
@@ -63,7 +63,7 @@ curl -H "Accept: text/markdown" https://neon.tech/docs/introduction/scale-to-zer
 Restore your database to any point within your retention window without backups.
 
 ```bash
-curl -H "Accept: text/markdown" https://neon.tech/docs/introduction/branch-restore
+curl -H "Accept: text/markdown" https://neon.com/docs/introduction/branch-restore
 ```
 
 **Key Points:**
@@ -78,7 +78,7 @@ curl -H "Accept: text/markdown" https://neon.tech/docs/introduction/branch-resto
 Create read-only compute endpoints to scale read workloads.
 
 ```bash
-curl -H "Accept: text/markdown" https://neon.tech/docs/introduction/read-replicas
+curl -H "Accept: text/markdown" https://neon.com/docs/introduction/read-replicas
 ```
 
 **Key Points:**
@@ -93,7 +93,7 @@ curl -H "Accept: text/markdown" https://neon.tech/docs/introduction/read-replica
 Built-in connection pooling via PgBouncer for efficient connection management.
 
 ```bash
-curl -H "Accept: text/markdown" https://neon.tech/docs/connect/connection-pooling
+curl -H "Accept: text/markdown" https://neon.com/docs/connect/connection-pooling
 ```
 
 **Key Points:**
@@ -108,7 +108,7 @@ curl -H "Accept: text/markdown" https://neon.tech/docs/connect/connection-poolin
 Restrict database access to specific IP addresses or ranges.
 
 ```bash
-curl -H "Accept: text/markdown" https://neon.tech/docs/introduction/ip-allow
+curl -H "Accept: text/markdown" https://neon.com/docs/introduction/ip-allow
 ```
 
 ## Logical Replication
@@ -116,7 +116,7 @@ curl -H "Accept: text/markdown" https://neon.tech/docs/introduction/ip-allow
 Replicate data to/from external Postgres databases.
 
 ```bash
-curl -H "Accept: text/markdown" https://neon.tech/docs/guides/logical-replication-guide
+curl -H "Accept: text/markdown" https://neon.com/docs/guides/logical-replication-guide
 ```
 
 ## Neon Auth
@@ -124,7 +124,7 @@ curl -H "Accept: text/markdown" https://neon.tech/docs/guides/logical-replicatio
 Managed authentication that branches with your database.
 
 ```bash
-curl -H "Accept: text/markdown" https://neon.tech/docs/auth/overview
+curl -H "Accept: text/markdown" https://neon.com/docs/auth/overview
 ```
 
 **Key Points:**
@@ -140,13 +140,13 @@ For setup, see `neon-auth.md`. For auth + data API, see `neon-js.md`.
 
 | Feature             | Documentation                                           | Resource       |
 | ------------------- | ------------------------------------------------------- | -------------- |
-| Branching           | https://neon.tech/docs/introduction/branching           | -              |
-| Autoscaling         | https://neon.tech/docs/introduction/autoscaling         | -              |
-| Scale to Zero       | https://neon.tech/docs/introduction/scale-to-zero       | -              |
-| Instant Restore     | https://neon.tech/docs/introduction/branch-restore      | -              |
-| Read Replicas       | https://neon.tech/docs/introduction/read-replicas       | -              |
-| Connection Pooling  | https://neon.tech/docs/connect/connection-pooling       | -              |
-| IP Allow            | https://neon.tech/docs/introduction/ip-allow            | -              |
-| Logical Replication | https://neon.tech/docs/guides/logical-replication-guide | -              |
-| Neon Auth           | https://neon.tech/docs/auth/overview                    | `neon-auth.md` |
-| Data API            | https://neon.tech/docs/data-api/overview                | `neon-js.md`   |
+| Branching           | https://neon.com/docs/introduction/branching           | -              |
+| Autoscaling         | https://neon.com/docs/introduction/autoscaling         | -              |
+| Scale to Zero       | https://neon.com/docs/introduction/scale-to-zero       | -              |
+| Instant Restore     | https://neon.com/docs/introduction/branch-restore      | -              |
+| Read Replicas       | https://neon.com/docs/introduction/read-replicas       | -              |
+| Connection Pooling  | https://neon.com/docs/connect/connection-pooling       | -              |
+| IP Allow            | https://neon.com/docs/introduction/ip-allow            | -              |
+| Logical Replication | https://neon.com/docs/guides/logical-replication-guide | -              |
+| Neon Auth           | https://neon.com/docs/auth/overview                    | `neon-auth.md` |
+| Data API            | https://neon.com/docs/data-api/overview                | `neon-js.md`   |

--- a/skills/neon-postgres/references/getting-started.md
+++ b/skills/neon-postgres/references/getting-started.md
@@ -5,7 +5,7 @@ Interactive guide to help users get started with Neon in their project. Sets up 
 For the official getting started guide:
 
 ```bash
-curl -H "Accept: text/markdown" https://neon.tech/docs/get-started/signing-up
+curl -H "Accept: text/markdown" https://neon.com/docs/get-started/signing-up
 ```
 
 ## Interactive Setup Flow
@@ -174,10 +174,10 @@ For detailed setup instructions, see `devtools.md`.
 
 | Topic              | URL                                                 |
 | ------------------ | --------------------------------------------------- |
-| Getting Started    | https://neon.tech/docs/get-started/signing-up       |
-| Connecting to Neon | https://neon.tech/docs/connect/connect-intro        |
-| Connection String  | https://neon.tech/docs/connect/connect-from-any-app |
-| Frameworks Guide   | https://neon.tech/docs/get-started/frameworks       |
-| ORMs Guide         | https://neon.tech/docs/get-started/orms             |
-| VSCode Extension   | https://neon.tech/docs/local/vscode-extension       |
-| MCP Server         | https://neon.tech/docs/ai/neon-mcp-server           |
+| Getting Started    | https://neon.com/docs/get-started/signing-up       |
+| Connecting to Neon | https://neon.com/docs/connect/connect-intro        |
+| Connection String  | https://neon.com/docs/connect/connect-from-any-app |
+| Frameworks Guide   | https://neon.com/docs/get-started/frameworks       |
+| ORMs Guide         | https://neon.com/docs/get-started/orms             |
+| VSCode Extension   | https://neon.com/docs/local/vscode-extension       |
+| MCP Server         | https://neon.com/docs/ai/neon-mcp-server           |

--- a/skills/neon-postgres/references/neon-auth.md
+++ b/skills/neon-postgres/references/neon-auth.md
@@ -8,7 +8,7 @@ Neon Auth provides authentication for your application. It's available as:
 For official documentation:
 
 ```bash
-curl -H "Accept: text/markdown" https://neon.tech/docs/auth/overview
+curl -H "Accept: text/markdown" https://neon.com/docs/auth/overview
 ```
 
 ## Package Selection

--- a/skills/neon-postgres/references/neon-cli.md
+++ b/skills/neon-postgres/references/neon-cli.md
@@ -16,12 +16,6 @@ brew install neonctl
 npm install -g neonctl
 ```
 
-**Direct download:**
-
-```bash
-curl -fsSL https://neon.tech/install.sh | bash
-```
-
 ## Authentication
 
 Authenticate with your Neon account:
@@ -150,15 +144,15 @@ Example GitHub Actions workflow:
 
 | Topic          | URL                                                    |
 | -------------- | ------------------------------------------------------ |
-| CLI Reference  | https://neon.tech/docs/reference/neon-cli              |
-| CLI Install    | https://neon.tech/docs/reference/cli-install           |
-| CLI Auth       | https://neon.tech/docs/reference/cli-auth              |
-| CLI Projects   | https://neon.tech/docs/reference/cli-projects          |
-| CLI Branches   | https://neon.tech/docs/reference/cli-branches          |
-| CLI Connection | https://neon.tech/docs/reference/cli-connection-string |
+| CLI Reference  | https://neon.com/docs/reference/neon-cli              |
+| CLI Install    | https://neon.com/docs/reference/cli-install           |
+| CLI Auth       | https://neon.com/docs/reference/cli-auth              |
+| CLI Projects   | https://neon.com/docs/reference/cli-projects          |
+| CLI Branches   | https://neon.com/docs/reference/cli-branches          |
+| CLI Connection | https://neon.com/docs/reference/cli-connection-string |
 
 Fetch CLI documentation:
 
 ```bash
-curl -H "Accept: text/markdown" https://neon.tech/docs/reference/neon-cli
+curl -H "Accept: text/markdown" https://neon.com/docs/reference/neon-cli
 ```

--- a/skills/neon-postgres/references/neon-drizzle.md
+++ b/skills/neon-postgres/references/neon-drizzle.md
@@ -5,7 +5,7 @@ Integration patterns, configurations, and optimizations for using **Drizzle ORM*
 For official documentation:
 
 ```bash
-curl -H "Accept: text/markdown" https://neon.tech/docs/guides/drizzle
+curl -H "Accept: text/markdown" https://neon.com/docs/guides/drizzle
 ```
 
 ## Choosing the Right Driver

--- a/skills/neon-postgres/references/neon-js.md
+++ b/skills/neon-postgres/references/neon-js.md
@@ -7,7 +7,7 @@ The `@neondatabase/neon-js` SDK provides a unified client for Neon Auth and Data
 For official documentation:
 
 ```bash
-curl -H "Accept: text/markdown" https://neon.tech/docs/reference/javascript-sdk
+curl -H "Accept: text/markdown" https://neon.com/docs/reference/javascript-sdk
 ```
 
 ## Package Selection

--- a/skills/neon-postgres/references/neon-platform-api.md
+++ b/skills/neon-postgres/references/neon-platform-api.md
@@ -15,16 +15,16 @@ The Neon Platform API allows you to manage Neon projects, branches, databases, a
 
 ```bash
 # REST API documentation
-curl -H "Accept: text/markdown" https://neon.tech/docs/reference/api-reference
+curl -H "Accept: text/markdown" https://neon.com/docs/reference/api-reference
 
 # TypeScript SDK
-curl -H "Accept: text/markdown" https://neon.tech/docs/reference/typescript-sdk
+curl -H "Accept: text/markdown" https://neon.com/docs/reference/typescript-sdk
 
 # Python SDK
-curl -H "Accept: text/markdown" https://neon.tech/docs/reference/python-sdk
+curl -H "Accept: text/markdown" https://neon.com/docs/reference/python-sdk
 
 # CLI
-curl -H "Accept: text/markdown" https://neon.tech/docs/reference/neon-cli
+curl -H "Accept: text/markdown" https://neon.com/docs/reference/neon-cli
 ```
 
 For the interactive API reference: https://api-docs.neon.tech/reference/getting-started-with-neon-api

--- a/skills/neon-postgres/references/neon-python-sdk.md
+++ b/skills/neon-postgres/references/neon-python-sdk.md
@@ -7,7 +7,7 @@ For core concepts (Organization, Project, Branch, Endpoint, etc.), see `what-is-
 ## Documentation
 
 ```bash
-curl -H "Accept: text/markdown" https://neon.tech/docs/reference/python-sdk
+curl -H "Accept: text/markdown" https://neon.com/docs/reference/python-sdk
 ```
 
 ## Installation

--- a/skills/neon-postgres/references/neon-serverless.md
+++ b/skills/neon-postgres/references/neon-serverless.md
@@ -5,7 +5,7 @@ Patterns and best practices for connecting to Neon databases in serverless envir
 For official documentation:
 
 ```bash
-curl -H "Accept: text/markdown" https://neon.tech/docs/serverless/serverless-driver
+curl -H "Accept: text/markdown" https://neon.com/docs/serverless/serverless-driver
 ```
 
 ## Installation
@@ -189,7 +189,7 @@ export const config = {
 };
 
 // For Cloudflare Workers, consider using Hyperdrive
-// https://neon.tech/blog/hyperdrive-neon-faq
+// https://neon.com/blog/hyperdrive-neon-faq
 ```
 
 ## ORM Integration

--- a/skills/neon-postgres/references/neon-typescript-sdk.md
+++ b/skills/neon-postgres/references/neon-typescript-sdk.md
@@ -7,7 +7,7 @@ For core concepts (Organization, Project, Branch, Endpoint, etc.), see `what-is-
 ## Documentation
 
 ```bash
-curl -H "Accept: text/markdown" https://neon.tech/docs/reference/typescript-sdk
+curl -H "Accept: text/markdown" https://neon.com/docs/reference/typescript-sdk
 ```
 
 ## Installation

--- a/skills/neon-postgres/references/referencing-docs.md
+++ b/skills/neon-postgres/references/referencing-docs.md
@@ -7,7 +7,7 @@ The Neon documentation is the source of truth for all Neon-related information. 
 To get a list of all available Neon documentation pages:
 
 ```bash
-curl https://neon.tech/llms.txt
+curl https://neon.com/llms.txt
 ```
 
 This returns an index of all documentation pages with their URLs and descriptions.
@@ -17,23 +17,23 @@ This returns an index of all documentation pages with their URLs and description
 To fetch any documentation page as markdown for review:
 
 ```bash
-curl -H "Accept: text/markdown" https://neon.tech/docs/<path>
+curl -H "Accept: text/markdown" https://neon.com/docs/<path>
 ```
 
 **Examples:**
 
 ```bash
 # Fetch the API reference
-curl -H "Accept: text/markdown" https://neon.tech/docs/reference/api-reference
+curl -H "Accept: text/markdown" https://neon.com/docs/reference/api-reference
 
 # Fetch connection pooling docs
-curl -H "Accept: text/markdown" https://neon.tech/docs/connect/connection-pooling
+curl -H "Accept: text/markdown" https://neon.com/docs/connect/connection-pooling
 
 # Fetch branching documentation
-curl -H "Accept: text/markdown" https://neon.tech/docs/introduction/branching
+curl -H "Accept: text/markdown" https://neon.com/docs/introduction/branching
 
 # Fetch serverless driver docs
-curl -H "Accept: text/markdown" https://neon.tech/docs/serverless/serverless-driver
+curl -H "Accept: text/markdown" https://neon.com/docs/serverless/serverless-driver
 ```
 
 ## Common Documentation Paths
@@ -55,16 +55,16 @@ curl -H "Accept: text/markdown" https://neon.tech/docs/serverless/serverless-dri
 
 ```bash
 # Next.js
-curl -H "Accept: text/markdown" https://neon.tech/docs/guides/nextjs
+curl -H "Accept: text/markdown" https://neon.com/docs/guides/nextjs
 
 # Django
-curl -H "Accept: text/markdown" https://neon.tech/docs/guides/django
+curl -H "Accept: text/markdown" https://neon.com/docs/guides/django
 
 # Drizzle ORM
-curl -H "Accept: text/markdown" https://neon.tech/docs/guides/drizzle
+curl -H "Accept: text/markdown" https://neon.com/docs/guides/drizzle
 
 # Prisma
-curl -H "Accept: text/markdown" https://neon.tech/docs/guides/prisma
+curl -H "Accept: text/markdown" https://neon.com/docs/guides/prisma
 ```
 
 ## Best Practices

--- a/skills/neon-postgres/references/what-is-neon.md
+++ b/skills/neon-postgres/references/what-is-neon.md
@@ -5,7 +5,7 @@ Neon is a serverless Postgres platform designed to help you build reliable and s
 For the full introduction, fetch the official docs:
 
 ```bash
-curl -H "Accept: text/markdown" https://neon.tech/docs/introduction
+curl -H "Accept: text/markdown" https://neon.com/docs/introduction
 ```
 
 ## Core Concepts
@@ -33,18 +33,18 @@ Understanding Neon's resource hierarchy is essential for working with the platfo
 
 | Topic                  | Documentation URL                                         |
 | ---------------------- | --------------------------------------------------------- |
-| Introduction           | https://neon.tech/docs/introduction                       |
-| Architecture           | https://neon.tech/docs/introduction/architecture-overview |
-| Plans & Billing        | https://neon.tech/docs/introduction/about-billing         |
-| Regions                | https://neon.tech/docs/introduction/regions               |
-| Postgres Compatibility | https://neon.tech/docs/reference/compatibility            |
+| Introduction           | https://neon.com/docs/introduction                       |
+| Architecture           | https://neon.com/docs/introduction/architecture-overview |
+| Plans & Billing        | https://neon.com/docs/introduction/about-billing         |
+| Regions                | https://neon.com/docs/introduction/regions               |
+| Postgres Compatibility | https://neon.com/docs/reference/compatibility            |
 
 ```bash
 # Fetch architecture docs
-curl -H "Accept: text/markdown" https://neon.tech/docs/introduction/architecture-overview
+curl -H "Accept: text/markdown" https://neon.com/docs/introduction/architecture-overview
 
 # Fetch plans and billing
-curl -H "Accept: text/markdown" https://neon.tech/docs/introduction/about-billing
+curl -H "Accept: text/markdown" https://neon.com/docs/introduction/about-billing
 ```
 
 ## When to Use Neon


### PR DESCRIPTION
Prevents redirect issues with curl. Also removed the neonctl install.sh curl example (no longer exists).