### PR TITLE
feat: add claimable postgres databases skill

### DIFF
--- a/skills/claimable-postgres/SKILL.md
+++ b/skills/claimable-postgres/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: claimable-postgres-databases
+name: claimable-postgres
 description: >-
   Provision instant temporary Postgres databases via Claimable Postgres by Neon
   (pg.new) with no login, signup, or credit card. Use when users ask for a
@@ -9,7 +9,7 @@ description: >-
   DATABASE_URL".
 ---
 
-# Claimable Postgres Databases
+# Claimable Postgres
 
 Create an instant Postgres database with Claimable Postgres by Neon (`pg.new`) for fast local development, demos, prototyping, and test environments.
 


### PR DESCRIPTION
## Summary
- add a new `claimable-postgres-databases` skill at `skills/claimable-postgres-databases/SKILL.md`
- focus the skill on quick temporary Postgres provisioning via `pg.new` without login/signup/credit card
- include practical agent workflow guidance for CLI (`npx get-db`), SDK, and REST API with safety notes

## Test plan
- [x] `skills-ref validate ./skills/claimable-postgres-databases`

Made with [Cursor](https://cursor.com)