### PR TITLE
neon-functions: document NEON_BRANCH (branch name) injected on every branch

### DIFF
--- a/skills/neon-functions/SKILL.md
+++ b/skills/neon-functions/SKILL.md
@@ -108,12 +108,15 @@ Neon injects branch-scoped connection strings and service URLs at runtime — yo
 
 | Variable                | Notes                                                                                    |
 | ----------------------- | ---------------------------------------------------------------------------------------- |
+| `NEON_BRANCH`           | The branch **name** (e.g. `main`, `preview/foo`). Injected on every branch, including the default. |
 | `DATABASE_URL`          | Pooled connection string. Use for most queries. Present only if the branch has Postgres. |
 | `DATABASE_URL_UNPOOLED` | Direct connection. Use for migrations, `LISTEN`/`NOTIFY`, multi-round-trip transactions. |
 | `NEON_AUTH_BASE_URL`    | Present when Neon Auth is enabled on the branch.                                         |
 | `NEON_DATA_API_URL`     | Present when the Data API is enabled on the branch.                                      |
 
 Object storage (`AWS_*`) and AI Gateway (`OPENAI_*`, `NEON_AI_GATEWAY_*`) vars are also injected when those services are declared — see the `neon-object-storage` and `neon-ai-gateway` skills.
+
+`neonctl env pull` / `neon-env run` / `neonctl dev` emit `NEON_BRANCH` (and the connection strings) into your local dev environment too, so local runs mirror the deployed runtime.
 
 **Your own secrets** are per-deployment. Set them with `--env KEY=VALUE` on `neonctl functions deploy` (repeatable; `--env KEY=` deletes a key, unmentioned keys carry over), or declare them in `neon.ts` under the function's `env` (resolved at deploy time, so read from `process.env` to avoid hardcoding):
 

--- a/skills/neon-functions/references/integrations.md
+++ b/skills/neon-functions/references/integrations.md
@@ -26,11 +26,11 @@ Sentry.init({
   dsn: process.env.SENTRY_DSN,
   enabled: Boolean(process.env.SENTRY_DSN),
   tracesSampleRate: 1.0,
-  // NEON_BRANCH (the branch id) is injected on EVERY branch, including the default — so it
+  // NEON_BRANCH (the branch name) is injected on EVERY branch, including the default — so it
   // can't be used as a truthy "is this a branch?" flag. Treat the project's default branch as
-  // "production" (its id passed in via neon.ts env) and tag every other branch by its id.
+  // "production" (its name passed in via neon.ts env) and tag every other branch by its name.
   environment:
-    process.env.NEON_BRANCH && process.env.NEON_BRANCH !== process.env.PRODUCTION_BRANCH_ID
+    process.env.NEON_BRANCH && process.env.NEON_BRANCH !== process.env.PRODUCTION_BRANCH
       ? process.env.NEON_BRANCH
       : "production",
 });
@@ -47,7 +47,7 @@ import { Hono } from "hono";
 ```
 
 - **Gate `enabled` on the DSN.** Local dev (`neonctl dev`) and any branch where you haven't configured the secret then become a no-op — no init, no noise — without changing code.
-- **Tag the environment off the injected branch id.** Each Neon branch runs its own copy of the function and the runtime injects `NEON_BRANCH` (the branch **id**, e.g. `br-rough-smoke-w2hoayam`) into every one of them — including the default branch. Because it's always present, don't use it as a boolean flag (that tags every branch the same). Instead compare it against your default branch id (pass it in as e.g. `PRODUCTION_BRANCH_ID` via `neon.ts` `env`) so the default branch reads as `production` and feature/preview branches are tagged by id — keeping them separable in the Sentry dashboard.
+- **Tag the environment off the injected branch name.** Each Neon branch runs its own copy of the function and the runtime injects `NEON_BRANCH` (the branch **name**, e.g. `main` or `preview/add-auth`) into every one of them — including the default branch. The same value is written into local dev by `neonctl env pull` / `neon-env run` / `neonctl dev`, so local and deployed runs agree. Because it's always present, don't use it as a boolean flag (that tags every branch the same). Instead compare it against your default branch name (pass it in as e.g. `PRODUCTION_BRANCH` via `neon.ts` `env`) so the default branch reads as `production` and feature/preview branches are tagged by name — keeping them separable in the Sentry dashboard.
 
 ### 2. Provide the DSN as a deploy-time secret
 


### PR DESCRIPTION
## Summary

Document `NEON_BRANCH`, which the Neon Functions runtime injects into every branch (including the default) by default — and which is now also written into local dev by `neonctl env pull` / `neon-env run` / `neonctl dev` (see neondatabase/neon-pkgs).

- Add `NEON_BRANCH` to the runtime env-var table in `neon-functions/SKILL.md`, noting it carries the branch **name** and is present on every branch, plus a line that local tooling emits it too.
- Update `references/integrations.md` Sentry env-tagging guidance: `NEON_BRANCH` is the branch **name** (was documented as the id); compare against the default branch name (`PRODUCTION_BRANCH`) so the default reads as `production` and other branches are tagged by name.

### Note on the value
This documents `NEON_BRANCH` as the branch **name** to match the env-pull change. If the runtime injects the branch **id** instead, the SKILL table row and the Sentry example should say "id" and compare against `PRODUCTION_BRANCH_ID`.

## Test plan

- [x] Markdown only; reviewed rendering and the updated Sentry example