### PR TITLE
docs: update neon init instructions for --agent boolean flag and --preview

### DIFF
--- a/skills/neon-postgres/SKILL.md
+++ b/skills/neon-postgres/SKILL.md
@@ -65,18 +65,24 @@ Before starting setup, inspect the user's codebase and environment:
 Offer to inspect existing connected Neon projects or create new ones using the Neon CLI or MCP server. If neither is set up yet, run init with the `--agent` flag. Use `npx -y` to skip the package install prompt. Auth is handled automatically. If the user is not logged in, it opens their browser for OAuth and waits for completion before proceeding.
 
 ```bash
-npx -y neonctl@latest init --agent <agent-name>
+npx -y neonctl@latest init --agent
 ```
 
-Supported `--agent` values: `cursor`, `copilot`, `claude`, `claude-desktop`, `codex`, `opencode`, `cline`, `gemini-cli`, `goose`, `zed`.
+The `--agent` flag is a boolean that enables agent/JSON mode. The agent type is auto-detected from the environment — no need to pass an agent name.
 
-This installs the Neon extension (for Cursor/VS Code) or MCP server (for other agents), creates an API key, and adds the `neon-postgres` agent skill to the project.
+Add `--preview` to enable preview features like project bootstrapping from templates and additional skills (neon-object-storage, neon-functions, neon-ai-gateway):
+
+```bash
+npx -y neonctl@latest init --agent --preview
+```
+
+This inspects the project, installs the Neon MCP server, agent skills, and editor extension (for Cursor/VS Code), connects to a Neon database, and optionally sets up Neon Auth. Already-configured components are detected and skipped automatically.
 
 If `init` is not suitable, the individual steps can be run non-interactively:
 
 - **Extension:** `cursor --install-extension databricks.neon-local-connect`
 - **MCP server:** `npx -y add-mcp https://mcp.neon.tech/mcp -g -n Neon -y -a <agent-name>`
-- **Agent skill:** `npx skills add neondatabase/agent-skills --skill neon-postgres --agent <agent-name> -y`
+- **Agent skill:** `npx skills add neondatabase/agent-skills --skill neon --skill neon-postgres --agent <agent-name> -y`
 
 For full CLI installation options, see https://neon.com/docs/reference/cli-install.md
 
@@ -177,7 +183,7 @@ Link: https://neon.com/docs/reference/javascript-sdk.md
 
 ## Developer Tools
 
-Use this for local development enablement with `npx -y neonctl@latest init --agent <agent-name>`, VSCode extension setup, and Neon MCP server configuration.
+Use this for local development enablement with `npx -y neonctl@latest init --agent`, VSCode extension setup, and Neon MCP server configuration.
 
 | Tool             | URL                                             |
 | ---------------- | ----------------------------------------------- |

--- a/skills/neon/SKILL.md
+++ b/skills/neon/SKILL.md
@@ -114,20 +114,28 @@ Before starting setup, inspect the user's codebase and environment:
 
 ### Self-Driving Setup With Neon's CLI or MCP Server
 
-Offer to inspect existing connected Neon projects or create new ones using the Neon CLI or MCP server. If neither is set up yet, run `npx -y neonctl init`. Use `npx -y` to skip the package install prompt. Auth is handled automatically. If the user is not logged in, it opens their browser for OAuth and waits for completion before proceeding.
+Offer to inspect existing connected Neon projects or create new ones using the Neon CLI or MCP server. If neither is set up yet, run init with the `--agent` flag. Use `npx -y` to skip the package install prompt. Auth is handled automatically. If the user is not logged in, it opens their browser for OAuth and waits for completion before proceeding.
 
 ```bash
-npx -y neonctl@latest init
+npx -y neonctl@latest init --agent
 ```
 
-This installs the Neon CLI and MCP server globally, installs the VSCode extension (for Cursor/VS Code), and adds the `neon` and `neon-postgres` agent skills to the project.
+The `--agent` flag is a boolean that enables agent/JSON mode. The agent type is auto-detected from the environment — no need to pass an agent name.
+
+Add `--preview` to enable preview features like project bootstrapping from templates and additional skills (neon-object-storage, neon-functions, neon-ai-gateway):
+
+```bash
+npx -y neonctl@latest init --agent --preview
+```
+
+This inspects the project, installs the Neon MCP server, agent skills, and editor extension (for Cursor/VS Code), connects to a Neon database, and optionally sets up Neon Auth. Already-configured components are detected and skipped automatically.
 
 If `init` is not suitable, the individual steps can be run non-interactively, using the user's preferred package manager (npm, bun, pnpm):
 
 - **CLI:** `npm i -g neonctl`
 - **Extension:** `cursor --install-extension databricks.neon-local-connect`
 - **MCP server:** `npx -y add-mcp https://mcp.neon.tech/mcp -g -n Neon -y -a <agent-name>`
-- **Agent skill:** `npx skills add neondatabase/agent-skills --skill neon-postgres --skill neon --agent <agent-name> -y`
+- **Agent skill:** `npx skills add neondatabase/agent-skills --skill neon --skill neon-postgres --agent <agent-name> -y`
 
 Prefer the CLI over the MCP server unless the user instructs otherwise, since it provides more capabilities, including deploying Neon Functions. For full CLI installation options, see https://neon.com/docs/reference/cli-install.md
 


### PR DESCRIPTION
## Summary

Updates the `neon` and `neon-postgres` agent skill documentation to reflect changes in `neon-init` v0.17.1:

- `--agent` is now a boolean flag — agent type is auto-detected from the environment, no need to pass an agent name
- Added `--preview` flag documentation for template bootstrapping and additional preview skills
- Updated skill install command to include both `neon` and `neon-postgres` skills
- Auth flow now asks users if they have an existing account or need to create one
- Already-configured components (MCP, skills, extension) are detected and skipped automatically

## Depends on

- https://github.com/neondatabase/neon-pkgs/pull/219 (neon-init changes)
- https://github.com/neondatabase/neonctl/pull/562 (neonctl changes, already merged)

This pull request and its description were written by Isaac.