### PR TITLE
docs: import @neondatabase packages from root (drop /v1)

### DIFF
--- a/skills/neon-ai-gateway/SKILL.md
+++ b/skills/neon-ai-gateway/SKILL.md
@@ -117,7 +117,7 @@ return result.toUIMessageStreamResponse();
 For multi-provider routing from a single call, the dedicated `@neondatabase/ai-sdk-provider` reads `NEON_AI_GATEWAY_BASE_URL` + `NEON_AI_GATEWAY_TOKEN` and routes each model to the best endpoint (Anthropic → Messages, OpenAI/Codex → Responses, everything else → MLflow):
 
 ```typescript
-import { neon } from "@neondatabase/ai-sdk-provider/v1";
+import { neon } from "@neondatabase/ai-sdk-provider";
 import { generateText } from "ai";
 
 const { text } = await generateText({
@@ -132,7 +132,7 @@ The `with-mastra` example runs a memory-backed agent (threads/messages in Postgr
 
 ```typescript
 import { Agent } from "@mastra/core/agent";
-import { parseEnv } from "@neondatabase/env/v1";
+import { parseEnv } from "@neondatabase/env";
 import config from "../neon";
 
 const env = parseEnv(config);

--- a/skills/neon-functions/SKILL.md
+++ b/skills/neon-functions/SKILL.md
@@ -78,7 +78,7 @@ A minimal function — a Hono app that queries the branch's Postgres via the inj
 import { Hono } from "hono";
 import { drizzle } from "drizzle-orm/node-postgres";
 import { Pool } from "pg";
-import { parseEnv } from "@neondatabase/env/v1";
+import { parseEnv } from "@neondatabase/env";
 import config from "../neon";
 import { todos } from "./db/schema";
 
@@ -203,7 +203,7 @@ process.on("SIGINT", () => {
 });
 ```
 
-> Reading `process.env.DATABASE_URL` directly works everywhere. The `with-hono` example in [Setup](#setup) instead uses `@neondatabase/env/v1`'s `parseEnv(config)` to read the same value in a typed, validated way — either is fine.
+> Reading `process.env.DATABASE_URL` directly works everywhere. The `with-hono` example in [Setup](#setup) instead uses `@neondatabase/env`'s `parseEnv(config)` to read the same value in a typed, validated way — either is fine.
 
 ## WebSocket servers
 
@@ -401,7 +401,7 @@ Functions are long-running but **still serverless** — they are a request/respo
 
 - **Time to first byte: 15 minutes.** Your handler must _begin_ returning a response within 15 minutes of receiving a request. Most handlers finish in seconds; the 15-minute ceiling exists so agent workloads like image/video generation have room.
 - **Heartbeat: 15 minutes.** Open WebSocket/SSE connections stay alive as long as data flows. The timeout only fires when a connection goes silent — send at least one byte every 15 minutes to keep a quiet stream alive.
-- **`waitUntil`: 15 minutes.** Work registered with `waitUntil` keeps the invocation alive after the response is sent, up to 15 minutes — for cleanup like analytics writes and audit logs, **not** a background job runner. (`waitUntil` from `@neondatabase/functions/v1` is currently a stub during the preview.)
+- **`waitUntil`: 15 minutes.** Work registered with `waitUntil` keeps the invocation alive after the response is sent, up to 15 minutes — for cleanup like analytics writes and audit logs, **not** a background job runner. (`waitUntil` from `@neondatabase/functions` is currently a stub during the preview.)
 - **Idle eviction.** With no active connections the platform shuts the function down; it may also evict/restart for operational reasons (active functions can run for hours first). Treat eviction like a process restart — WebSocket/SSE clients must reconnect. The platform sends `SIGINT` before evicting, so register a handler to drain gracefully:
 
 ```typescript

--- a/skills/neon-functions/references/mastra-studio.md
+++ b/skills/neon-functions/references/mastra-studio.md
@@ -11,7 +11,7 @@ Use the gateway's **MLflow (chat-completions) dialect**, which serves every prov
 ```typescript
 // src/mastra/agents/pricing.ts
 import { Agent } from "@mastra/core/agent";
-import { parseEnv } from "@neondatabase/env/v1";
+import { parseEnv } from "@neondatabase/env";
 import config from "../../../neon";
 
 const env = parseEnv(config);

--- a/skills/neon-postgres/SKILL.md
+++ b/skills/neon-postgres/SKILL.md
@@ -273,7 +273,7 @@ Since `neon.ts` is TypeScript, invalid combinations fail to compile with an acti
 Read the resulting env back, typed and validated against the policy, with `parseEnv` from `@neondatabase/env`:
 
 ```typescript
-import { parseEnv } from "@neondatabase/env/v1";
+import { parseEnv } from "@neondatabase/env";
 import config from "./neon";
 
 const env = parseEnv(config);

--- a/skills/neon/SKILL.md
+++ b/skills/neon/SKILL.md
@@ -239,7 +239,7 @@ npm i @neondatabase/env
 ```
 
 ```typescript
-import { parseEnv } from "@neondatabase/env/v1";
+import { parseEnv } from "@neondatabase/env";
 import config from "./neon";
 
 const env = parseEnv(config);
@@ -251,7 +251,7 @@ console.log(env.auth.baseUrl);
 By default `parseEnv` requires _every_ variable your config implies. When a process only uses a subset — a common case in frameworks like Next.js, where you might read `DATABASE_URL` but never the unpooled URL — pass an array of env-var keys to require and return only those. The keys are typesafe: autocomplete only offers variables your config enables, and the returned shape is narrowed to exactly what you selected (so unselected variables are neither enforced nor present).
 
 ```typescript
-import { parseEnv } from "@neondatabase/env/v1";
+import { parseEnv } from "@neondatabase/env";
 import config from "./neon";
 
 // Only DATABASE_URL is required and returned; DATABASE_URL_UNPOOLED is not enforced.


### PR DESCRIPTION
## Summary

Updates the skill snippets to import `@neondatabase/env`, `@neondatabase/functions`, and `@neondatabase/ai-sdk-provider` from the **package root** instead of the `/v1` subpath. The `/v1` subpath export is being removed from those three packages (see neondatabase/neon-pkgs#232); the root already exposes the same surface. `@neondatabase/config/v1` is left unchanged (it keeps its versioned subpath).

Touched: `neon`, `neon-postgres`, `neon-functions` (+ `references/mastra-studio.md`), and `neon-ai-gateway`.

## Test plan

- [x] No `@neondatabase/{env,functions,ai-sdk-provider}/v1` references remain in `skills/`