### PR TITLE
docs(readme): link agent platforms skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ An overview of the Neon platform for apps and agents — Postgres, Auth, Data AP
 
 A comprehensive index of Neon Serverless Postgres documentation and best practices to set your agents up for success.
 
+### Neon Postgres Agent Platforms
+
+[![neon-postgres-agent-platforms](https://shieldcn.dev/skills/installs/neondatabase/neon-for-agent-platforms/neon-postgres-agent-platforms.svg?variant=branded&size=xs&label=neon-postgres-agent-platforms)](https://skills.sh/neondatabase/neon-for-agent-platforms/neon-postgres-agent-platforms)
+
+For agent platforms, codegen tools, and multi-tenant SaaS products that provision and run Neon Postgres for their users. Includes a companion skill and samples in [neondatabase/neon-for-agent-platforms](https://github.com/neondatabase/neon-for-agent-platforms).
+
 ### Neon Postgres Branches
 
 [![neon-postgres-branches](https://shieldcn.dev/skills/installs/neondatabase/agent-skills/neon-postgres-branches.svg?variant=branded&size=xs&label=neon-postgres-branches)](https://skills.sh/neondatabase/agent-skills/neon-postgres-branches)


### PR DESCRIPTION
Link the companion Neon Postgres Agent Platforms skill and repository from the README.