### PR TITLE
chore: add skills.sh page config

### DIFF
--- a/skills.sh.json
+++ b/skills.sh.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://skills.sh/schemas/skills.sh.schema.json",
+  "notGrouped": "bottom",
+  "groupings": [
+    {
+      "title": "Core",
+      "description": "Start here for Neon platform and Postgres guidance.",
+      "skills": [
+        "neon",
+        "neon-postgres"
+      ]
+    },
+    {
+      "title": "Database Workflows",
+      "description": "Provision, branch, and optimize Postgres projects.",
+      "skills": [
+        "claimable-postgres",
+        "neon-postgres-branches",
+        "neon-postgres-egress-optimizer"
+      ]
+    },
+    {
+      "title": "Neon Platform",
+      "description": "Use Neon services beyond core Postgres.",
+      "skills": [
+        "neon-ai-gateway",
+        "neon-functions",
+        "neon-object-storage"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add root `skills.sh.json` for skills.sh repository page customization.
- Group local Neon skill slugs into Core, Database Workflows, and Neon Platform sections.

## Test plan
- `python3 -m json.tool skills.sh.json >/dev/null`
- Cursor lints for `skills.sh.json`