### PR TITLE
docs(neon-ai-gateway): use cleaned-up gateway paths (/v1, /openai/v1, /anthropic/v1)

### DIFF
--- a/skills/neon-ai-gateway/SKILL.md
+++ b/skills/neon-ai-gateway/SKILL.md
@@ -82,14 +82,14 @@ When `preview.aiGateway` is enabled, Neon injects the gateway credentials as **N
 
 > Neon injects **only** these two vars — it does **not** set `OPENAI_API_KEY` / `OPENAI_BASE_URL`. The `@neon/ai-sdk-provider` and Mastra's `neon/<model>` read `NEON_AI_GATEWAY_*` directly (zero config); for the plain OpenAI SDK / `@ai-sdk/openai`, build the client's `apiKey` + `baseURL` from them (shown below), or set your own `OPENAI_*` by hand (`env pull` leaves user-set vars untouched).
 
-`NEON_AI_GATEWAY_BASE_URL` is the **bare host** — you append `/ai-gateway/<dialect>` yourself (which is exactly what the `@neon/ai-sdk-provider` does for you). The routes under the host are:
+`NEON_AI_GATEWAY_BASE_URL` is the **bare host** — you append the dialect path yourself (which is exactly what the `@neon/ai-sdk-provider` does for you). The routes under the host are:
 
-- `/ai-gateway/mlflow/v1` — unified, OpenAI **Chat Completions**-compatible; recommended default, works with every provider.
-- `/ai-gateway/openai/v1` — OpenAI **Responses** API (required for `gpt-5-…-codex` variants and `gpt-5-5-pro`); the `@ai-sdk/openai` provider uses the Responses API by default.
-- `/ai-gateway/anthropic/v1` — native Anthropic Messages (extended thinking, prompt caching).
-- `/ai-gateway/gemini/v1beta/...` — native Gemini `generateContent`.
+- `/v1` — unified, OpenAI **Chat Completions**-compatible; recommended default, works with every provider (`/v1/chat/completions`).
+- `/openai/v1` — OpenAI **Responses** API (required for `gpt-5-…-codex` variants and `gpt-5-5-pro`); the `@ai-sdk/openai` provider uses the Responses API by default (`/openai/v1/responses`).
+- `/anthropic/v1` — native Anthropic Messages (extended thinking, prompt caching); mirrors the real Anthropic API path (`/anthropic/v1/messages`).
+- `/ai-gateway/gemini/v1beta/...` — native Gemini `generateContent` (this dialect is still served under the legacy `/ai-gateway/` prefix).
 
-So `${NEON_AI_GATEWAY_BASE_URL}/ai-gateway/mlflow/v1` is the chat-completions endpoint, `${NEON_AI_GATEWAY_BASE_URL}/ai-gateway/openai/v1` the OpenAI Responses endpoint, and so on.
+So `${NEON_AI_GATEWAY_BASE_URL}/v1` is the chat-completions endpoint, `${NEON_AI_GATEWAY_BASE_URL}/openai/v1` the OpenAI Responses endpoint, and so on.
 
 For typed access, `parseEnv` (from `@neon/env`) returns `env.aiGateway` (`apiKey`, `baseUrl`) derived from your `neon.ts`.
 
@@ -128,7 +128,7 @@ const { text } = await generateText({
 });
 ```
 
-> Prefer `@neon/ai-sdk-provider` over the bare `@ai-sdk/openai` `openai()`: Neon injects only `NEON_AI_GATEWAY_*`, not `OPENAI_*`, so `openai()` won't pick up the gateway from the env on its own. If you do use `@ai-sdk/openai`, configure it explicitly with `createOpenAI({ apiKey: process.env.NEON_AI_GATEWAY_TOKEN, baseURL: `${process.env.NEON_AI_GATEWAY_BASE_URL}/ai-gateway/openai/v1` })`.
+> Prefer `@neon/ai-sdk-provider` over the bare `@ai-sdk/openai` `openai()`: Neon injects only `NEON_AI_GATEWAY_*`, not `OPENAI_*`, so `openai()` won't pick up the gateway from the env on its own. If you do use `@ai-sdk/openai`, configure it explicitly with `createOpenAI({ apiKey: process.env.NEON_AI_GATEWAY_TOKEN, baseURL: `${process.env.NEON_AI_GATEWAY_BASE_URL}/openai/v1` })`.
 
 To build an **agent** — a model that calls tools in a loop and then answers — add `tools` and a `stopWhen` budget. The loop runs in-process, so on a Neon Function it isn't cut off by lambda-style timeouts:
 
@@ -183,7 +183,7 @@ import OpenAI from "openai";
 
 const client = new OpenAI({
   apiKey: process.env.NEON_AI_GATEWAY_TOKEN,
-  baseURL: `${process.env.NEON_AI_GATEWAY_BASE_URL}/ai-gateway/openai/v1`,
+  baseURL: `${process.env.NEON_AI_GATEWAY_BASE_URL}/openai/v1`,
 });
 
 const res = await client.responses.create({
@@ -192,12 +192,12 @@ const res = await client.responses.create({
 });
 ```
 
-For the unified **chat-completions** dialect, point `baseURL` at `/mlflow/v1` instead:
+For the unified **chat-completions** dialect, point `baseURL` at `/v1` instead:
 
 ```typescript
 const client = new OpenAI({
   apiKey: process.env.NEON_AI_GATEWAY_TOKEN,
-  baseURL: `${process.env.NEON_AI_GATEWAY_BASE_URL}/ai-gateway/mlflow/v1`,
+  baseURL: `${process.env.NEON_AI_GATEWAY_BASE_URL}/v1`,
 });
 
 const res = await client.chat.completions.create({
@@ -206,7 +206,7 @@ const res = await client.chat.completions.create({
 });
 ```
 
-The Anthropic SDK and google-genai work the same way for native provider features — point them at the `/anthropic` and `/gemini` routes on the bare gateway host (`${NEON_AI_GATEWAY_BASE_URL}/ai-gateway/anthropic`, `${NEON_AI_GATEWAY_BASE_URL}/ai-gateway/gemini`).
+The Anthropic SDK and google-genai work the same way for native provider features — point the Anthropic SDK at `${NEON_AI_GATEWAY_BASE_URL}/anthropic/v1` (mirrors the real Anthropic API path, so `/anthropic/v1/messages`) and google-genai at `${NEON_AI_GATEWAY_BASE_URL}/ai-gateway/gemini` (Gemini is still served under the legacy `/ai-gateway/` prefix).
 
 ## Model identifiers
 


### PR DESCRIPTION
## Summary

The Neon AI Gateway now serves tidier top-level routes. Update the `neon-ai-gateway` skill's documented base URLs and SDK examples to match:

- **Chat completions (all models):** `${NEON_AI_GATEWAY_BASE_URL}/v1` → `/v1/chat/completions` (was `/ai-gateway/mlflow/v1`)
- **OpenAI Responses:** `${NEON_AI_GATEWAY_BASE_URL}/openai/v1` → `/openai/v1/responses` (was `/ai-gateway/openai/v1`)
- **Anthropic Messages:** `${NEON_AI_GATEWAY_BASE_URL}/anthropic/v1` → `/anthropic/v1/messages`, mirroring the real Anthropic API path (was `/ai-gateway/anthropic/v1`)
- **Gemini:** left as `${NEON_AI_GATEWAY_BASE_URL}/ai-gateway/gemini/v1beta` — this dialect is **not** cleaned up yet; the bare `/gemini/v1beta` route 404s.

All four dialects were verified live against the gateway with a real branch token:

| Dialect | Clean route | Result |
| --- | --- | --- |
| Chat completions | `/v1/chat/completions` | ✅ 200 |
| OpenAI Responses | `/openai/v1/responses` | ✅ 200 |
| Anthropic Messages | `/anthropic/v1/messages` | ✅ 200 |
| Gemini generateContent | `/gemini/v1beta/…` | ❌ 404 (kept on `/ai-gateway/gemini/v1beta`, ✅ 200) |

Pairs with the models.dev provider update (anomalyco/models.dev#3198).

## Test plan

- [x] Live curl of all four dialects against the gateway
- [ ] Re-install the skill into repos that vendor it (see note)

> Note: this is the skill **source** repo. Repos that vendor `neon-ai-gateway` should refresh via `npx skills add neondatabase/agent-skills -s neon-ai-gateway -a <agent> -y` after merge.