### PR TITLE
docs(neon-ai-gateway): drop stale "MLflow" jargon for "chat completions"

### DIFF
--- a/skills/neon-ai-gateway/SKILL.md
+++ b/skills/neon-ai-gateway/SKILL.md
@@ -34,7 +34,7 @@ If the user already has a deep, single-provider integration and no interest in N
 ## What It Does
 
 - **One API for all models** — Frontier and open-source models behind a single endpoint, addressed by their catalog ID (e.g. `claude-sonnet-4-6`, `gpt-5-mini`, `gemini-2-5-flash`).
-- **Standard SDKs, one URL change** — OpenAI SDK and AI SDK (OpenAI-compatible MLflow/Responses routes), Anthropic SDK (native Messages), google-genai (native Gemini).
+- **Standard SDKs, one URL change** — OpenAI-compatible chat completions and Responses routes, Anthropic SDK (native Messages), google-genai (native Gemini).
 - **Branch-scoped** — Each branch gets its own gateway host; the Neon credential authorizes requests for that branch and its descendants.
 - **Streaming** — Server-sent events work on all endpoints with no extra configuration.
 
@@ -97,7 +97,7 @@ For typed access, `parseEnv` (from `@neon/env`) returns `env.aiGateway` (`apiKey
 
 The [Vercel AI SDK](https://ai-sdk.dev) is the recommended way to call the gateway and build agents from TypeScript: one set of primitives (`generateText`, `streamText`, tool calling, structured output) over every catalog model, with first-class streaming for the long agent responses Neon Functions are built to host.
 
-The dedicated `@neon/ai-sdk-provider` reads `NEON_AI_GATEWAY_BASE_URL` + `NEON_AI_GATEWAY_TOKEN` from the injected env with **zero config** and routes each model to the best endpoint (Anthropic → Messages, OpenAI/Codex → Responses, everything else → MLflow). On a Neon Function that streams text and generates images, just pick a catalog model:
+The dedicated `@neon/ai-sdk-provider` reads `NEON_AI_GATEWAY_BASE_URL` + `NEON_AI_GATEWAY_TOKEN` from the injected env with **zero config** and routes each model to the best endpoint (Anthropic → Messages, OpenAI/Codex → Responses, everything else → chat completions). On a Neon Function that streams text and generates images, just pick a catalog model:
 
 ```typescript
 import { neon } from "@neon/ai-sdk-provider";

--- a/skills/neon-functions/references/ai-sdk.md
+++ b/skills/neon-functions/references/ai-sdk.md
@@ -27,7 +27,7 @@ export default defineConfig({
 
 ## 2. The handler: stream a tool-calling agent
 
-The function's default export is a web-standard `{ fetch }` handler. The `@neon/ai-sdk-provider` reads the injected gateway credentials automatically, so `neon("<model>")` is all the model config you need — it routes each model to the right dialect (Anthropic → Messages, OpenAI/Codex → Responses, everything else → MLflow). Return `result.toUIMessageStreamResponse()` so the AI SDK's `useChat` hooks can consume the stream:
+The function's default export is a web-standard `{ fetch }` handler. The `@neon/ai-sdk-provider` reads the injected gateway credentials automatically, so `neon("<model>")` is all the model config you need — it routes each model to the right dialect (Anthropic → Messages, OpenAI/Codex → Responses, everything else → chat completions). Return `result.toUIMessageStreamResponse()` so the AI SDK's `useChat` hooks can consume the stream:
 
 ```typescript
 // src/index.ts

--- a/skills/neon-functions/references/mastra-studio.md
+++ b/skills/neon-functions/references/mastra-studio.md
@@ -6,7 +6,7 @@ The shape mirrors any other Node integration (see `references/sentry.md`): insta
 
 ## 1. Define the agent against the Neon AI Gateway
 
-With `@mastra/core` 1.47+, use a `neon/<model>` magic string — Mastra reads `NEON_AI_GATEWAY_BASE_URL` and `NEON_AI_GATEWAY_TOKEN` from the environment (injected by `neon deploy` / `neon env pull` when `preview.aiGateway` is enabled in `neon.ts`). No manual `url`/`apiKey` or MLflow dialect swap is needed; Mastra routes each model to the correct gateway endpoint.
+With `@mastra/core` 1.47+, use a `neon/<model>` magic string — Mastra reads `NEON_AI_GATEWAY_BASE_URL` and `NEON_AI_GATEWAY_TOKEN` from the environment (injected by `neon deploy` / `neon env pull` when `preview.aiGateway` is enabled in `neon.ts`). No manual `url`/`apiKey` or dialect swap is needed; Mastra routes each model to the correct gateway endpoint.
 
 ```typescript
 // src/mastra/agents/pricing.ts


### PR DESCRIPTION
Chained on top of #50. Salvages the **only still-valid slice** of #44 and #37 after a line-by-line review against the sources of truth (console AI Gateway examples, `neondatabase/examples` source, `@neon/env` + `@neon/ai-sdk-provider` READMEs).

## What this changes

Replaces the residual, unexplained **"MLflow"** jargon with **"chat completions"** in 4 spots:

- `skills/neon-ai-gateway/SKILL.md` — "What It Does" bullet + the `@neon/ai-sdk-provider` routing line (`everything else → MLflow` → `→ chat completions`)
- `skills/neon-functions/references/ai-sdk.md` — same routing line
- `skills/neon-functions/references/mastra-studio.md` — "or MLflow dialect swap" → "or dialect swap"

### Why

The unified route is now `/v1` **chat completions** (not the legacy `/ai-gateway/mlflow/v1`). The skills never define "MLflow", so a bare `→ MLflow` leaks unexplained internal jargon. The console AI Gateway examples and the rest of the already-reconciled skill consistently say "chat completions". (The `@neon/ai-sdk-provider` README still uses "MLflow endpoint" internally — that's fine; it's not user-facing skill copy.)

## Why nothing else from #44 / #37

Both PRs predate the reconciliation now on `main`, and their remaining changes are **outdated or regressive** against the SoT:

- ❌ `NEON_AI_GATEWAY_BASE_URL` → `NEON_AI_GATEWAY_HOST` (#37) — SoT keeps `NEON_AI_GATEWAY_BASE_URL`
- ❌ Re-introducing / relying on injected `OPENAI_*` (both) — Neon injects **only** `NEON_AI_GATEWAY_TOKEN` + `NEON_AI_GATEWAY_BASE_URL`
- ❌ `@neon/*` → `@neondatabase/*` package renames (#44) — conflicts with #50; example source uses `@neon/*`
- ❌ `neon` → `neonctl` CLI (#44) — regresses the modern IaC CLI
- ❌ Mastra `model: "neon/<model>"` → verbose `{ id, url, apiKey }` (#44) — main + `with-mastra` example use the magic string

Recommend closing #44 and #37 as superseded once this lands.

## Test plan

- [x] `skills-ref validate skills/neon-ai-gateway` and `skills/neon-functions` pass
- [ ] Merge after #50