### PR TITLE
Run Validate on ubuntu-latest so npm ci can reach the registry

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -33,9 +33,9 @@ permissions:
 jobs:
   validate:
     name: Validate
-    runs-on:
-      group: neondatabase-protected-runner-group
-      labels: linux-ubuntu-latest
+    # ubuntu-latest, not neondatabase-protected-runner-group: npm ci fetches
+    # from the public registry, which the protected group cannot reach.
+    runs-on: ubuntu-latest
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.11.0


### PR DESCRIPTION
## Problem

Every `Validate` run has failed since 2026-07-14. The last green run was `Validate Plugins` on 2026-03-17.

`npm ci` cannot reach `registry.npmjs.org`:

```
npm error code ECONNRESET
npm error network request to https://registry.npmjs.org/skills-ref/-/skills-ref-0.1.5.tgz failed,
  reason: Client network socket disconnected before secure TLS connection was established
```

The job runs on `neondatabase-protected-runner-group`, which reaches internal Databricks services and the Neon Management API but not the public internet.

## Diagnosis

Two commits landed eight minutes apart, neither wrong on its own:

| Commit | Change | Safe because |
|---|---|---|
| `ad76d53` | `runs-on: ubuntu-latest` → protected runner group | `package.json` had no dependencies, so the install step fetched nothing |
| `9811646` | added `skills-ref@0.1.5`, `npm install` → `npm ci` | assumed a runner with public egress |

Together, a job with no public egress has to fetch tarballs from a public registry.

Evidence the boundary is egress and not a flaky registry:

- Four consecutive runs fail on the same package with the same pre-TLS `ECONNRESET`, across `push`, `pull_request`, and a Dependabot branch — runs [30647948110](https://github.com/neondatabase/agent-skills/actions/runs/30647948110), [30637238096](https://github.com/neondatabase/agent-skills/actions/runs/30637238096), [30635354045](https://github.com/neondatabase/agent-skills/actions/runs/30635354045), [30464891396](https://github.com/neondatabase/agent-skills/actions/runs/30464891396).
- Dependabot's own `npm_and_yarn` graph updates fail on the same runner while its `github_actions` updates succeed. Same boundary, second signal.
- `npm run validate:ci` passes locally against `main`, so nothing downstream of the install is broken.

## Change

```diff
   validate:
     name: Validate
-    runs-on:
-      group: neondatabase-protected-runner-group
-      labels: linux-ubuntu-latest
+    # ubuntu-latest, not neondatabase-protected-runner-group: npm ci fetches
+    # from the public registry, which the protected group cannot reach.
+    runs-on: ubuntu-latest
```

The job checks out a public repo, installs public devDependencies, and validates markdown. It touches no internal service, no Neon Management API, and no secret, and already declares `permissions: contents: read`. `neon-pkgs` splits its jobs on exactly this rule and records the reason in a comment per job, which is what the added comment follows.

SHA-pinned actions and the `harden-runner` egress audit are unchanged.

## Verification

`.github/workflows/validate.yml` is in this workflow's own `paths` filter, so the `Validate` check on this PR runs the changed file and is the verification.

Locally on `main`, with dependencies installed:

```
$ npm run validate:ci
[OK] All 8 skill(s) have a fully-linked reference graph.
```

## Alternative not taken

Point npm at the Databricks JFrog mirror the way `neon-pkgs/.github/actions/prepare` does, keeping the job on the protected group. That adds an OIDC-authenticated composite action and a registry override to a workflow that only reads public files — cost without a matching benefit.

## Flagged

- A `workflow_dispatch` run from 2026-07-27 ([30294019149](https://github.com/neondatabase/agent-skills/actions/runs/30294019149)) has been queued for over 100 hours against the protected group. `cancel` and `force-cancel` both return HTTP 500 and `delete` returns 403, so it is stuck GitHub-side and not fixable from here. It does not block this PR.
- `prettier` is installed on every CI run but `validate:ci` never invokes it — only `npm run fmt` does. Left alone deliberately: it is a legitimate devDependency, and now that the job has public egress and a warm npm cache the cost is seconds.