### PR TITLE
Say "Lakebase Postgres on Neon" in the three ambiguous blurbs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ An overview of Neon for apps and agents — Lakebase Postgres, Auth, Data API, O
 
 [![neon-postgres](https://shieldcn.dev/skills/installs/neondatabase/agent-skills/neon-postgres.svg?variant=branded&size=xs&label=neon-postgres)](https://skills.sh/neondatabase/agent-skills/neon-postgres)
 
-A comprehensive index of Lakebase Postgres documentation and best practices to set your agents up for success.
+A comprehensive index of documentation and best practices for Lakebase Postgres on Neon, to set your agents up for success.
 
 ### Neon Postgres Agent Platforms
 

--- a/plugins/neon-postgres/skills/neon/SKILL.md
+++ b/plugins/neon-postgres/skills/neon/SKILL.md
@@ -85,7 +85,7 @@ The skills below live in the [`neondatabase/agent-skills`](https://github.com/ne
 | `claimable-postgres` | Provisioning instant, claimable temporary Postgres databases (for example, one per end user or demo). |
 | `neon-postgres-egress-optimizer` | Diagnosing or fixing excessive Postgres egress (network data-transfer) costs in a codebase. |
 
-For guidance on agent platforms that provision and operate Lakebase Postgres at scale, use `neon-postgres-agent-platforms`, which lives in a separate repo: [`neondatabase/neon-for-agent-platforms`](https://github.com/neondatabase/neon-for-agent-platforms).
+For guidance on agent platforms that provision and operate Lakebase Postgres on Neon at scale, use `neon-postgres-agent-platforms`, which lives in a separate repo: [`neondatabase/neon-for-agent-platforms`](https://github.com/neondatabase/neon-for-agent-platforms).
 
 ### Installing the Right Skill
 

--- a/skills.sh.json
+++ b/skills.sh.json
@@ -12,7 +12,7 @@
     },
     {
       "title": "Database Workflows",
-      "description": "Provision, branch, and optimize Lakebase Postgres projects.",
+      "description": "Provision, branch, and optimize Lakebase Postgres projects on Neon.",
       "skills": [
         "claimable-postgres",
         "neon-postgres-branches",

--- a/skills/neon/SKILL.md
+++ b/skills/neon/SKILL.md
@@ -85,7 +85,7 @@ The skills below live in the [`neondatabase/agent-skills`](https://github.com/ne
 | `claimable-postgres` | Provisioning instant, claimable temporary Postgres databases (for example, one per end user or demo). |
 | `neon-postgres-egress-optimizer` | Diagnosing or fixing excessive Postgres egress (network data-transfer) costs in a codebase. |
 
-For guidance on agent platforms that provision and operate Lakebase Postgres at scale, use `neon-postgres-agent-platforms`, which lives in a separate repo: [`neondatabase/neon-for-agent-platforms`](https://github.com/neondatabase/neon-for-agent-platforms).
+For guidance on agent platforms that provision and operate Lakebase Postgres on Neon at scale, use `neon-postgres-agent-platforms`, which lives in a separate repo: [`neondatabase/neon-for-agent-platforms`](https://github.com/neondatabase/neon-for-agent-platforms).
 
 ### Installing the Right Skill
 


### PR DESCRIPTION
Follow-up to [#65](https://github.com/neondatabase/agent-skills/pull/65), which named the database Lakebase Postgres. This applies the disambiguation rule the team settled in the naming thread, which landed after that PR merged.

## Problem

Lakebase Postgres is reachable two ways — through Neon or through Databricks. The rule: **if a statement is accurate across both, don't disambiguate; if it only holds on the Neon path, say "Lakebase Postgres on Neon."** Plus: name the path in SEO descriptions and blurbs, skip it in body copy where context is already established.

Three strings here fail that test. Each is Neon-specific, names no access path, and is read detached from any heading that would supply one:

| File | Before | After |
|---|---|---|
| `skills.sh.json` | "Provision, branch, and optimize Lakebase Postgres projects." | "…Lakebase Postgres projects **on Neon**." |
| `README.md` | "A comprehensive index of Lakebase Postgres documentation and best practices…" | "A comprehensive index of documentation and best practices for **Lakebase Postgres on Neon**…" |
| `skills/neon/SKILL.md` | "…provision and operate Lakebase Postgres at scale" | "…provision and operate **Lakebase Postgres on Neon** at scale" |

The `skills.sh.json` one renders in the registry listing, where "projects" is a Neon API concept and Databricks Lakebase has no equivalent. The README blurb indexes `neon.com/docs`. The third describes running fleets of Neon orgs and projects.

The README sentence was reordered rather than having the phrase wedged in — "index of Lakebase Postgres on Neon documentation" doesn't parse.

## Left bare, deliberately

Twenty-odd other occurrences keep saying just "Lakebase Postgres", because inserting the phrase would either be redundant or wrong:

- **The sentence already says Neon.** "Neon's Lakebase Postgres offering", "Use Neon services beyond Lakebase Postgres", "the database behind Neon", "Neon provides the backend primitives (Lakebase Postgres, Auth, …)", "Every project ships with Lakebase Postgres; `neon.ts` lets you also declare Neon Auth", "create databases on Neon … a Lakebase Postgres data layer".
- **The claim holds on both access paths.** The primitives bullet ("built on the lakebase architecture: OLTP directly on cloud object storage"), and `# Lakebase Postgres Branching`.
- **The next paragraph does the disambiguating better than a suffix would.** `# Lakebase Postgres` in `neon-postgres` is followed immediately by "It is the same database whether you reach it through Neon or through Databricks; this skill covers the Neon access path." Adding "on Neon" to the heading would duplicate that and imply the heading's subject is narrower than it is.

## Verification

```
npm run sync:plugins    plugin copies regenerated from skills/
npm run validate:ci     8/8 skills valid, plugin copies in sync, reference graph linked
```

No skill id, plugin id, or heading renamed. Nothing changes for anyone installing a skill.

## For your attention

- **[`neondatabase/examples`](https://github.com/neondatabase/examples) vendors 39 copies of these skills** and will go stale the moment this merges. It needs a `skills update` refresh afterwards; I'm handling that in the `examples` follow-up PR, which is sequenced behind this one.
- **Four more repos carry the same rule now.** [neon-for-agent-platforms](https://github.com/neondatabase/neon-for-agent-platforms) has one equivalent blurb, `examples` has three strings, and [mcp-server-neon#314](https://github.com/neondatabase/mcp-server-neon/pull/314) and [neon-pkgs#363](https://github.com/neondatabase/neon-pkgs/pull/363) already have it applied.