### PR TITLE
Describe the plugin as the whole Neon backend, not just Postgres

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,10 +12,10 @@
     {
       "name": "neon-postgres",
       "source": "./plugins/neon-postgres",
-      "description": "Manage your Neon projects, databases, and branches with the Neon agent skills and the Neon MCP Server",
+      "description": "Manage your Neon backend with the Neon agent skills and the Neon MCP Server: Lakebase Postgres, branching, Object Storage, Functions, and the AI Gateway",
       "version": "1.1.0",
       "category": "database",
-      "tags": ["postgres", "serverless", "database", "mcp", "neon"]
+      "tags": ["neon", "lakebase", "postgres", "serverless", "database", "mcp"]
     }
   ]
 }

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -13,7 +13,7 @@
     {
       "name": "neon-postgres",
       "source": "neon-postgres",
-      "description": "Manage your Neon projects, databases, and branches with the Neon agent skills and the Neon MCP Server"
+      "description": "Manage your Neon backend with the Neon agent skills and the Neon MCP Server: Lakebase Postgres, branching, Object Storage, Functions, and the AI Gateway"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ npx skills add neondatabase/agent-skills
 
 ### Claude Code Plugin
 
-You can also install the skills as a Claude Code plugin, which bundles the Neon agent skills (`neon`, `neon-postgres`, `neon-postgres-branches`) and the [Neon MCP Server](https://mcp.neon.tech) for natural language database management:
+You can also install the skills as a Claude Code plugin, which bundles the Neon agent skills and the [Neon MCP Server](https://mcp.neon.tech) for natural language database management:
 
 ```
 /plugin marketplace add neondatabase/agent-skills

--- a/plugins/neon-postgres/.claude-plugin/plugin.json
+++ b/plugins/neon-postgres/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "neon",
   "version": "1.1.0",
-  "description": "Manage your Neon projects, databases, and branches with the Neon agent skills and the Neon MCP Server",
+  "description": "Manage your Neon backend with the Neon agent skills and the Neon MCP Server: Lakebase Postgres, branching, Object Storage, Functions, and the AI Gateway",
   "author": {
     "name": "Neon",
     "url": "https://neon.com"
@@ -9,7 +9,7 @@
   "homepage": "https://neon.com",
   "repository": "https://github.com/neondatabase/agent-skills",
   "license": "Apache-2.0",
-  "keywords": ["neon", "postgres", "serverless", "database", "mcp"],
+  "keywords": ["neon", "lakebase", "postgres", "serverless", "database", "mcp"],
   "skills": "./skills/",
   "mcpServers": "./mcp.json"
 }

--- a/plugins/neon-postgres/.cursor-plugin/plugin.json
+++ b/plugins/neon-postgres/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "neon-postgres",
   "displayName": "Neon Postgres",
   "version": "1.1.0",
-  "description": "Manage your Neon projects, databases, and branches with the Neon agent skills and the Neon MCP Server",
+  "description": "Manage your Neon backend with the Neon agent skills and the Neon MCP Server: Lakebase Postgres, branching, Object Storage, Functions, and the AI Gateway",
   "author": {
     "name": "Neon",
     "email": "andre@neon.tech"
@@ -10,7 +10,7 @@
   "homepage": "https://neon.tech/docs/ai/neon-mcp-server",
   "repository": "https://github.com/neondatabase/agent-skills",
   "license": "Apache-2.0",
-  "keywords": ["neon", "postgres", "serverless", "database", "mcp", "cursor"],
+  "keywords": ["neon", "lakebase", "postgres", "serverless", "database", "mcp", "cursor"],
   "logo": "assets/logo.svg",
   "skills": "./skills/",
   "mcpServers": "./mcp.json"


### PR DESCRIPTION
## Summary

- Broadens the plugin description in all four manifests (`.claude-plugin/marketplace.json`, `.cursor-plugin/marketplace.json`, and both plugin manifests) from "projects, databases, and branches" to name the primitives the plugin actually ships: Lakebase Postgres, branching, Object Storage, Functions, and the AI Gateway. The `neon-object-storage`, `neon-functions`, and `neon-ai-gateway` skills were already vendored, so this is a copy fix, not a scope change.
- Adds `lakebase` as a keyword (both plugin manifests) and tag (Claude marketplace), ordered right after `neon` so the primary brand term stays first.
- Removes the hardcoded skill list from the README's Claude Code Plugin section. It had drifted to three of the eight vendored skills; leaving the names out keeps it accurate as skills are added or removed.

No version bump, matching how previous copy-only changes (a454387, 3a23361) were handled — releases go out in a dedicated bump commit.

## Test plan

- [x] `npm run validate:ci` passes (plugin skills in sync, all 8 skills valid, reference graph fully linked)
- [x] Pre-commit `sync:plugins` hook ran and produced no vendored-copy drift
- [x] Description string is byte-identical across all four manifests
- [ ] Confirm the description renders acceptably in the Claude and Cursor plugin listings (it is longer than the previous one)
- [ ] After merge: mirror the description into the downstream marketplaces that vendor their own copies — [openai/plugins](https://github.com/openai/plugins) (`plugins/neon-postgres/`) and [xai-org/plugin-marketplace](https://github.com/xai-org/plugin-marketplace) (`external_plugins/neon/`)