### PR TITLE
neon-ai-gateway: provider-prefixed dialect paths, and stop mentioning the long form

### DIFF
--- a/plugins/neon-postgres/skills/neon-ai-gateway/SKILL.md
+++ b/plugins/neon-postgres/skills/neon-ai-gateway/SKILL.md
@@ -112,7 +112,7 @@ When `preview.aiGateway` is enabled, Neon injects the gateway credentials as **N
 - `/v1` — unified, OpenAI **Chat Completions**-compatible; recommended default, works with every provider (`/v1/chat/completions`).
 - `/openai/v1` — OpenAI **Responses** API (required for `gpt-5-…-codex` variants and `gpt-5-5-pro`); the `@ai-sdk/openai` provider uses the Responses API by default (`/openai/v1/responses`).
 - `/anthropic/v1` — native Anthropic Messages (extended thinking, prompt caching); mirrors the real Anthropic API path (`/anthropic/v1/messages`).
-- `/ai-gateway/gemini/v1beta/...` — native Gemini `generateContent` (this dialect is still served under the legacy `/ai-gateway/` prefix).
+- `/v1/gemini/v1beta/...` — native Gemini `generateContent`. The short form keeps a `gemini` segment rather than being a bare `/v1` route; a bare `/gemini/v1beta/...` is not served.
 
 So `${NEON_AI_GATEWAY_BASE_URL}/v1` is the chat-completions endpoint, `${NEON_AI_GATEWAY_BASE_URL}/openai/v1` the OpenAI Responses endpoint, and so on.
 
@@ -231,7 +231,9 @@ const res = await client.chat.completions.create({
 });
 ```
 
-The Anthropic SDK and google-genai work the same way for native provider features — point the Anthropic SDK at `${NEON_AI_GATEWAY_BASE_URL}/anthropic/v1` (mirrors the real Anthropic API path, so `/anthropic/v1/messages`) and google-genai at `${NEON_AI_GATEWAY_BASE_URL}/ai-gateway/gemini` (Gemini is still served under the legacy `/ai-gateway/` prefix).
+The Anthropic SDK and google-genai work the same way for native provider features — point the Anthropic SDK at `${NEON_AI_GATEWAY_BASE_URL}/anthropic` (it appends `/v1/messages` itself) and google-genai at `${NEON_AI_GATEWAY_BASE_URL}/v1/gemini` (it appends `/v1beta/models/...`).
+
+Every dialect is also reachable at a longer `/ai-gateway/<dialect>/...` path. Both forms behave identically and neither is deprecated, but prefer the short one — it is what the docs and SDKs use.
 
 ## Model Identifiers
 

--- a/plugins/neon-postgres/skills/neon-ai-gateway/SKILL.md
+++ b/plugins/neon-postgres/skills/neon-ai-gateway/SKILL.md
@@ -112,7 +112,7 @@ When `preview.aiGateway` is enabled, Neon injects the gateway credentials as **N
 - `/v1` — unified, OpenAI **Chat Completions**-compatible; recommended default, works with every provider (`/v1/chat/completions`).
 - `/openai/v1` — OpenAI **Responses** API (required for `gpt-5-…-codex` variants and `gpt-5-5-pro`); the `@ai-sdk/openai` provider uses the Responses API by default (`/openai/v1/responses`).
 - `/anthropic/v1` — native Anthropic Messages (extended thinking, prompt caching); mirrors the real Anthropic API path (`/anthropic/v1/messages`).
-- `/v1/gemini/v1beta/...` — native Gemini `generateContent`. The `/v1beta` is Google's own API version, not Neon's.
+- `/gemini/v1beta/...` — native Gemini `generateContent`. The `/v1beta` is Google's own API version, not Neon's.
 
 So `${NEON_AI_GATEWAY_BASE_URL}/v1` is the chat-completions endpoint, `${NEON_AI_GATEWAY_BASE_URL}/openai/v1` the OpenAI Responses endpoint, and so on.
 
@@ -231,7 +231,7 @@ const res = await client.chat.completions.create({
 });
 ```
 
-The Anthropic SDK and google-genai work the same way for native provider features — point the Anthropic SDK at `${NEON_AI_GATEWAY_BASE_URL}/anthropic` (it appends `/v1/messages` itself) and google-genai at `${NEON_AI_GATEWAY_BASE_URL}/v1/gemini` (it appends `/v1beta/models/...`).
+The Anthropic SDK and google-genai work the same way for native provider features — point the Anthropic SDK at `${NEON_AI_GATEWAY_BASE_URL}/anthropic` (it appends `/v1/messages` itself) and google-genai at `${NEON_AI_GATEWAY_BASE_URL}/gemini` (it appends `/v1beta/models/...`).
 
 ## Model Identifiers
 

--- a/plugins/neon-postgres/skills/neon-ai-gateway/SKILL.md
+++ b/plugins/neon-postgres/skills/neon-ai-gateway/SKILL.md
@@ -112,7 +112,7 @@ When `preview.aiGateway` is enabled, Neon injects the gateway credentials as **N
 - `/v1` — unified, OpenAI **Chat Completions**-compatible; recommended default, works with every provider (`/v1/chat/completions`).
 - `/openai/v1` — OpenAI **Responses** API (required for `gpt-5-…-codex` variants and `gpt-5-5-pro`); the `@ai-sdk/openai` provider uses the Responses API by default (`/openai/v1/responses`).
 - `/anthropic/v1` — native Anthropic Messages (extended thinking, prompt caching); mirrors the real Anthropic API path (`/anthropic/v1/messages`).
-- `/v1/gemini/v1beta/...` — native Gemini `generateContent`. The short form keeps a `gemini` segment rather than being a bare `/v1` route; a bare `/gemini/v1beta/...` is not served.
+- `/v1/gemini/v1beta/...` — native Gemini `generateContent`. The `/v1beta` is Google's own API version, not Neon's.
 
 So `${NEON_AI_GATEWAY_BASE_URL}/v1` is the chat-completions endpoint, `${NEON_AI_GATEWAY_BASE_URL}/openai/v1` the OpenAI Responses endpoint, and so on.
 
@@ -232,8 +232,6 @@ const res = await client.chat.completions.create({
 ```
 
 The Anthropic SDK and google-genai work the same way for native provider features — point the Anthropic SDK at `${NEON_AI_GATEWAY_BASE_URL}/anthropic` (it appends `/v1/messages` itself) and google-genai at `${NEON_AI_GATEWAY_BASE_URL}/v1/gemini` (it appends `/v1beta/models/...`).
-
-Every dialect is also reachable at a longer `/ai-gateway/<dialect>/...` path. Both forms behave identically and neither is deprecated, but prefer the short one — it is what the docs and SDKs use.
 
 ## Model Identifiers
 

--- a/skills/neon-ai-gateway/SKILL.md
+++ b/skills/neon-ai-gateway/SKILL.md
@@ -112,7 +112,7 @@ When `preview.aiGateway` is enabled, Neon injects the gateway credentials as **N
 - `/v1` — unified, OpenAI **Chat Completions**-compatible; recommended default, works with every provider (`/v1/chat/completions`).
 - `/openai/v1` — OpenAI **Responses** API (required for `gpt-5-…-codex` variants and `gpt-5-5-pro`); the `@ai-sdk/openai` provider uses the Responses API by default (`/openai/v1/responses`).
 - `/anthropic/v1` — native Anthropic Messages (extended thinking, prompt caching); mirrors the real Anthropic API path (`/anthropic/v1/messages`).
-- `/ai-gateway/gemini/v1beta/...` — native Gemini `generateContent` (this dialect is still served under the legacy `/ai-gateway/` prefix).
+- `/v1/gemini/v1beta/...` — native Gemini `generateContent`. The short form keeps a `gemini` segment rather than being a bare `/v1` route; a bare `/gemini/v1beta/...` is not served.
 
 So `${NEON_AI_GATEWAY_BASE_URL}/v1` is the chat-completions endpoint, `${NEON_AI_GATEWAY_BASE_URL}/openai/v1` the OpenAI Responses endpoint, and so on.
 
@@ -231,7 +231,9 @@ const res = await client.chat.completions.create({
 });
 ```
 
-The Anthropic SDK and google-genai work the same way for native provider features — point the Anthropic SDK at `${NEON_AI_GATEWAY_BASE_URL}/anthropic/v1` (mirrors the real Anthropic API path, so `/anthropic/v1/messages`) and google-genai at `${NEON_AI_GATEWAY_BASE_URL}/ai-gateway/gemini` (Gemini is still served under the legacy `/ai-gateway/` prefix).
+The Anthropic SDK and google-genai work the same way for native provider features — point the Anthropic SDK at `${NEON_AI_GATEWAY_BASE_URL}/anthropic` (it appends `/v1/messages` itself) and google-genai at `${NEON_AI_GATEWAY_BASE_URL}/v1/gemini` (it appends `/v1beta/models/...`).
+
+Every dialect is also reachable at a longer `/ai-gateway/<dialect>/...` path. Both forms behave identically and neither is deprecated, but prefer the short one — it is what the docs and SDKs use.
 
 ## Model Identifiers
 

--- a/skills/neon-ai-gateway/SKILL.md
+++ b/skills/neon-ai-gateway/SKILL.md
@@ -112,7 +112,7 @@ When `preview.aiGateway` is enabled, Neon injects the gateway credentials as **N
 - `/v1` — unified, OpenAI **Chat Completions**-compatible; recommended default, works with every provider (`/v1/chat/completions`).
 - `/openai/v1` — OpenAI **Responses** API (required for `gpt-5-…-codex` variants and `gpt-5-5-pro`); the `@ai-sdk/openai` provider uses the Responses API by default (`/openai/v1/responses`).
 - `/anthropic/v1` — native Anthropic Messages (extended thinking, prompt caching); mirrors the real Anthropic API path (`/anthropic/v1/messages`).
-- `/v1/gemini/v1beta/...` — native Gemini `generateContent`. The `/v1beta` is Google's own API version, not Neon's.
+- `/gemini/v1beta/...` — native Gemini `generateContent`. The `/v1beta` is Google's own API version, not Neon's.
 
 So `${NEON_AI_GATEWAY_BASE_URL}/v1` is the chat-completions endpoint, `${NEON_AI_GATEWAY_BASE_URL}/openai/v1` the OpenAI Responses endpoint, and so on.
 
@@ -231,7 +231,7 @@ const res = await client.chat.completions.create({
 });
 ```
 
-The Anthropic SDK and google-genai work the same way for native provider features — point the Anthropic SDK at `${NEON_AI_GATEWAY_BASE_URL}/anthropic` (it appends `/v1/messages` itself) and google-genai at `${NEON_AI_GATEWAY_BASE_URL}/v1/gemini` (it appends `/v1beta/models/...`).
+The Anthropic SDK and google-genai work the same way for native provider features — point the Anthropic SDK at `${NEON_AI_GATEWAY_BASE_URL}/anthropic` (it appends `/v1/messages` itself) and google-genai at `${NEON_AI_GATEWAY_BASE_URL}/gemini` (it appends `/v1beta/models/...`).
 
 ## Model Identifiers
 

--- a/skills/neon-ai-gateway/SKILL.md
+++ b/skills/neon-ai-gateway/SKILL.md
@@ -112,7 +112,7 @@ When `preview.aiGateway` is enabled, Neon injects the gateway credentials as **N
 - `/v1` — unified, OpenAI **Chat Completions**-compatible; recommended default, works with every provider (`/v1/chat/completions`).
 - `/openai/v1` — OpenAI **Responses** API (required for `gpt-5-…-codex` variants and `gpt-5-5-pro`); the `@ai-sdk/openai` provider uses the Responses API by default (`/openai/v1/responses`).
 - `/anthropic/v1` — native Anthropic Messages (extended thinking, prompt caching); mirrors the real Anthropic API path (`/anthropic/v1/messages`).
-- `/v1/gemini/v1beta/...` — native Gemini `generateContent`. The short form keeps a `gemini` segment rather than being a bare `/v1` route; a bare `/gemini/v1beta/...` is not served.
+- `/v1/gemini/v1beta/...` — native Gemini `generateContent`. The `/v1beta` is Google's own API version, not Neon's.
 
 So `${NEON_AI_GATEWAY_BASE_URL}/v1` is the chat-completions endpoint, `${NEON_AI_GATEWAY_BASE_URL}/openai/v1` the OpenAI Responses endpoint, and so on.
 
@@ -232,8 +232,6 @@ const res = await client.chat.completions.create({
 ```
 
 The Anthropic SDK and google-genai work the same way for native provider features — point the Anthropic SDK at `${NEON_AI_GATEWAY_BASE_URL}/anthropic` (it appends `/v1/messages` itself) and google-genai at `${NEON_AI_GATEWAY_BASE_URL}/v1/gemini` (it appends `/v1beta/models/...`).
-
-Every dialect is also reachable at a longer `/ai-gateway/<dialect>/...` path. Both forms behave identically and neither is deprecated, but prefer the short one — it is what the docs and SDKs use.
 
 ## Model Identifiers
 


### PR DESCRIPTION
## The problem

The skill sent agents to the wrong URLs in two ways.

It told them to point `google-genai` at `${NEON_AI_GATEWAY_BASE_URL}/ai-gateway/gemini` and
described that prefix as where Gemini "is still served", which reads as though it were the only
route. And it pointed the Anthropic SDK at `/anthropic/v1` — the SDK appends `/v1/messages`
itself, so that yields `/anthropic/v1/v1/messages` and a 404.

## The change

```diff
- google-genai at ${NEON_AI_GATEWAY_BASE_URL}/ai-gateway/gemini
+ google-genai at ${NEON_AI_GATEWAY_BASE_URL}/gemini

- Anthropic SDK at ${NEON_AI_GATEWAY_BASE_URL}/anthropic/v1
+ Anthropic SDK at ${NEON_AI_GATEWAY_BASE_URL}/anthropic
```

Every native dialect is now written provider-prefixed at the root, matching how the skill already
described `/openai/v1`:

| Dialect | Path |
| --- | --- |
| Chat completions | `/v1/chat/completions` |
| OpenAI Responses | `/openai/v1/responses` |
| Anthropic Messages | `/anthropic/v1/messages` |
| Gemini | `/gemini/v1beta/models/{model}:action` |

The `/v1beta` in the Gemini route is Google's own API version, not Neon's — the skill says so, so
an agent does not read it as a Neon versioning inconsistency and "fix" it.

**The longer `/ai-gateway/<dialect>/…` form is no longer mentioned anywhere.** It still resolves
and is not deprecated, so nothing breaks for code already using it — it is simply not something we
document. An earlier revision of this PR added a line saying it exists and to prefer the short
form; that is gone too, along with the phrase "the short form", which implied an alternative.

## Verified against a live gateway branch

| Path | Result |
| --- | --- |
| `/anthropic/v1/messages` | 200 on all 11 Claude ids |
| `/openai/v1/responses` | 200 |
| `/v1/chat/completions` | 200 |
| `/gemini/v1beta/...` | **404 today** |

**The Gemini path lands ahead of the gateway.** `/v1/gemini/v1beta/...` is what serves right now;
the customer-facing route is moving to the provider-prefixed form in
[neondatabase/website#5456](https://github.com/neondatabase/website/pull/5456), and this ships in
step with it. Calling that out rather than implying the whole table was measured together — an
agent using this skill before the gateway change deploys will get a 404 on Gemini's native
dialect and should fall back to `/v1/chat/completions`, which serves every Gemini model.

## Downstream

Consumers vendor this skill and need a re-install to pick it up. The website enforces that with
`check:skills-sync` against upstream `main`, so it will flag the drift once this merges. The
plugin mirror under `plugins/neon-postgres/skills/` is synced in the same commits —
`validate:plugin-skills` fails otherwise.