### PR TITLE
neon-ai-gateway: drop the note explaining Gemini's version segment

### DIFF
--- a/plugins/neon-postgres/skills/neon-ai-gateway/SKILL.md
+++ b/plugins/neon-postgres/skills/neon-ai-gateway/SKILL.md
@@ -112,7 +112,7 @@ When `preview.aiGateway` is enabled, Neon injects the gateway credentials as **N
 - `/v1` — unified, OpenAI **Chat Completions**-compatible; recommended default, works with every provider (`/v1/chat/completions`).
 - `/openai/v1` — OpenAI **Responses** API (required for `gpt-5-…-codex` variants and `gpt-5-5-pro`); the `@ai-sdk/openai` provider uses the Responses API by default (`/openai/v1/responses`).
 - `/anthropic/v1` — native Anthropic Messages (extended thinking, prompt caching); mirrors the real Anthropic API path (`/anthropic/v1/messages`).
-- `/gemini/v1beta/...` — native Gemini `generateContent`. The `/v1beta` is Google's own API version, not Neon's.
+- `/gemini/v1beta/...` — native Gemini `generateContent` (`/gemini/v1beta/models/<model>:generateContent`).
 
 So `${NEON_AI_GATEWAY_BASE_URL}/v1` is the chat-completions endpoint, `${NEON_AI_GATEWAY_BASE_URL}/openai/v1` the OpenAI Responses endpoint, and so on.
 

--- a/skills/neon-ai-gateway/SKILL.md
+++ b/skills/neon-ai-gateway/SKILL.md
@@ -112,7 +112,7 @@ When `preview.aiGateway` is enabled, Neon injects the gateway credentials as **N
 - `/v1` — unified, OpenAI **Chat Completions**-compatible; recommended default, works with every provider (`/v1/chat/completions`).
 - `/openai/v1` — OpenAI **Responses** API (required for `gpt-5-…-codex` variants and `gpt-5-5-pro`); the `@ai-sdk/openai` provider uses the Responses API by default (`/openai/v1/responses`).
 - `/anthropic/v1` — native Anthropic Messages (extended thinking, prompt caching); mirrors the real Anthropic API path (`/anthropic/v1/messages`).
-- `/gemini/v1beta/...` — native Gemini `generateContent`. The `/v1beta` is Google's own API version, not Neon's.
+- `/gemini/v1beta/...` — native Gemini `generateContent` (`/gemini/v1beta/models/<model>:generateContent`).
 
 So `${NEON_AI_GATEWAY_BASE_URL}/v1` is the chat-completions endpoint, `${NEON_AI_GATEWAY_BASE_URL}/openai/v1` the OpenAI Responses endpoint, and so on.
 


### PR DESCRIPTION
## The problem

The route list said:

> `/gemini/v1beta/...` — native Gemini `generateContent`. The `/v1beta` is Google's own API
> version, not Neon's.

I added that in [#77](https://github.com/neondatabase/agent-skills/pull/77) to stop an agent
reading `v1beta` as an inconsistency and "correcting" it to `v1`. It has the opposite effect:
explaining it frames Gemini as an exception, which is the reading it was meant to prevent.

Gemini is not an exception. Every native dialect is `/<provider>/<that provider's own API
version>`:

```
/openai/v1
/anthropic/v1
/gemini/v1beta
```

The version segment differs because the providers version differently. The list is uniform, so it
can just be read.

## The change

```diff
- - `/gemini/v1beta/...` — native Gemini `generateContent`. The `/v1beta` is Google's own API version, not Neon's.
+ - `/gemini/v1beta/...` — native Gemini `generateContent` (`/gemini/v1beta/models/<model>:generateContent`).
```

The replacement adds the full path shape, which is the part an agent actually needs, and drops the
commentary.

Plugin mirror synced in the same commit — `validate:plugin-skills` fails otherwise.

## Verification

`npm run validate:ci` — all 8 skills pass, reference graph fully linked.