### PR TITLE
Make the repo root installable as an Agent Plugins v1 package

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Official Neon plugins for Claude Code",
-    "version": "1.1.0"
+    "version": "1.1.1"
   },
   "plugins": [
     {
       "name": "neon-postgres",
       "source": "./plugins/neon-postgres",
       "description": "Manage your Neon backend with the Neon agent skills and the Neon MCP Server: Lakebase Postgres, branching, Object Storage, Functions, and the AI Gateway",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "category": "database",
       "tags": ["neon", "lakebase", "postgres", "serverless", "database", "mcp"]
     }

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Official Neon plugins for Cursor",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "pluginRoot": "plugins"
   },
   "plugins": [

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -3,5 +3,29 @@ set -e
 
 # Keep vendored plugin skills in sync with the top-level source of truth so
 # committed plugins always ship real skill files. See CONTRIBUTING.md.
+#
+# Staged a directory at a time so a deleted skill is staged too. Safe to stage
+# wholesale because every file under it is generated: sync-plugin-skills.mjs
+# overwrites them from skills/ on every run, so there is no hand edit to catch.
+# The -d test matters because an unmatched glob is passed through literally,
+# and git add on a literal pattern aborts the commit with a pathspec error.
 node scripts/sync-plugin-skills.mjs
-git add plugins/*/skills
+for skills_dir in plugins/*/skills; do
+  if [ -d "$skills_dir" ]; then
+    git add "$skills_dir"
+  fi
+done
+
+# Keep every manifest's version in step with package.json, the single source
+# of truth, so a release is one edit rather than six.
+#
+# Stages only the paths the script reports rewriting, which it prints to
+# stdout. These manifests are hand-authored apart from the version field, so
+# staging them wholesale would sweep an in-progress edit to a description or
+# keyword list into an unrelated commit.
+synced_files=$(node scripts/sync-versions.mjs)
+if [ -n "$synced_files" ]; then
+  while IFS= read -r versioned_file; do
+    git add "$versioned_file"
+  done <<<"$synced_files"
+fi

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,8 +1,9 @@
 name: Validate
 
-# Skill and plugin validation. Supply-chain hardened: SHA-pinned actions,
-# npm ci --ignore-scripts from package-lock.json, harden-runner egress audit.
-# Keep aligned with neondatabase/neon-for-agent-platforms — see AGENTS.md.
+# Skill and plugin validation, covering the root Agent Plugins v1 package and
+# the Claude/Cursor packaging under plugins/. Supply-chain hardened: SHA-pinned
+# actions, npm ci --ignore-scripts from package-lock.json, harden-runner egress
+# audit. Keep aligned with neondatabase/neon-for-agent-platforms — see AGENTS.md.
 
 on:
   pull_request:
@@ -10,6 +11,10 @@ on:
       - 'skills/**'
       - 'plugins/**'
       - 'scripts/**'
+      - 'plugin.json'
+      - 'mcp.json'
+      - '.claude-plugin/**'
+      - '.cursor-plugin/**'
       - 'package.json'
       - 'package-lock.json'
       - '.github/workflows/validate.yml'
@@ -21,6 +26,10 @@ on:
       - 'skills/**'
       - 'plugins/**'
       - 'scripts/**'
+      - 'plugin.json'
+      - 'mcp.json'
+      - '.claude-plugin/**'
+      - '.cursor-plugin/**'
       - 'package.json'
       - 'package-lock.json'
       - '.github/workflows/validate.yml'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,19 @@ For the complete Agent Skills specification, see: https://agentskills.io/specifi
 
 A collection of skills for coding agents for working with Neon. Skills are packaged instructions and documentation that extend the agent's capabilities.
 
+## The repo root is a portable Agent Plugins v1 package
+
+The root [`plugin.json`](plugin.json) and [`mcp.json`](mcp.json) make this repository directly installable by any client that implements the [Agent Plugins v1 specification](https://agent-plugins.org/specification). Everything the portable format defines lives at the root: the manifest, the MCP configuration, and the skills as immediate children of `skills/`.
+
+Rules to keep in mind when touching these files:
+
+- The `plugin.json` schema is **closed**. Only `$schema`, `name`, `version`, `description`, `author`, `homepage`, `repository`, `license`, `keywords`, and `extensions` are allowed. Client fields such as `skills`, `mcpServers`, `hooks`, or `logo` are nonconforming at the top level — MCP servers go in `mcp.json`, skills are discovered from `skills/`, and anything else client-specific goes under a reverse-domain `extensions` namespace owned by the client.
+- `mcp.json` transports are `stdio`, `streamable-http`, or `sse`. Note that this differs from `plugins/neon-postgres/mcp.json`, which uses Claude/Cursor's `http` spelling; the two files are intentionally not identical.
+- Only immediate children of `skills/` are discovered, and each `SKILL.md` frontmatter `name` must match its directory.
+- Hooks, agents, commands, LSP servers, and the `marketplace.json` catalogs are **not** portable v1 components. Hooks and the rest belong inside a plugin under `plugins/`; the catalogs stay at the repo root in `.claude-plugin/` and `.cursor-plugin/`, where Claude Code and Cursor look for them, and point back into `plugins/`. v1 only claims `plugin.json`, `mcp.json`, and `skills/`, so conforming clients ignore those extra root directories.
+
+`npm run validate:agent-plugin` (part of `validate:ci`) enforces the manifest, MCP, and skill-discovery rules above. The last bullet is a packaging convention, not a checked rule.
+
 ## Downstream Marketplaces — Keep in Sync
 
 This repo (`skills/`) is the source of truth. The Neon skills are also published as plugins in external marketplaces that **vendor their own copies** of the skill files, so changes here do **not** propagate automatically. Whenever you add or change a skill, open a PR in each downstream marketplace to mirror it:
@@ -157,7 +170,7 @@ Use the skills-ref tool to validate your skills:
 ```bash
 npm ci --ignore-scripts
 npm run validate:skills
-# or the full CI gate (skills + plugins):
+# or the full CI gate:
 npm run validate:ci
 ```
 
@@ -177,13 +190,44 @@ The plugins under `plugins/` are distributed as git repositories, and Cursor/Cla
 
 When you add or change a skill that a plugin ships, run `npm run sync:plugins` (or just commit — the hook handles it).
 
+The root Agent Plugins package is the exception: it reads `skills/` directly, so it needs no vendoring and no sync step.
+
+## Releasing: bump package.json
+
+[`package.json`](package.json) holds the plugin version. Every other manifest that declares one is **generated** from it, the same way `plugins/*/skills` is generated from `skills/`:
+
+| File | Field |
+| --- | --- |
+| [`plugin.json`](plugin.json) | `version` |
+| [`.claude-plugin/marketplace.json`](.claude-plugin/marketplace.json) | `metadata.version` and `plugins[].version` |
+| [`.cursor-plugin/marketplace.json`](.cursor-plugin/marketplace.json) | `metadata.version` |
+| [`plugins/neon-postgres/.claude-plugin/plugin.json`](plugins/neon-postgres/.claude-plugin/plugin.json) | `version` |
+| [`plugins/neon-postgres/.cursor-plugin/plugin.json`](plugins/neon-postgres/.cursor-plugin/plugin.json) | `version` |
+
+So a release is one edit:
+
+```bash
+npm version patch --no-git-tag-version   # or minor / major
+git commit -am "Release the accumulated skill changes"
+```
+
+The pre-commit hook runs `npm run sync:versions` and stages the rewritten manifests. `npm run validate:versions` is the same script in `--check` mode and runs as part of `validate:ci`, so a manifest edited by hand, or a commit made with the hook bypassed, still fails the build. When it does, the failure names its own fix: `npm run sync:versions` for a stale manifest, `npm install --ignore-scripts` for the lockfile below, and a hand edit for a manifest that has lost its `version` field.
+
+Do not edit those version fields directly — the hook will overwrite them from `package.json` on the next commit.
+
+`package-lock.json` carries the version too, in `version` and `packages[""].version`. `npm version` updates it and `git commit -a` stages it, so it is **checked but never written**: rewriting it by text match is unsafe because it repeats `"version"` for every dependency. If it drifts, run `npm install --ignore-scripts`, which rewrites it from `package.json`. Reach for that rather than editing it, because `npx` can quietly restore the old version from `node_modules/.package-lock.json`.
+
+The table is what the manifests happen to declare today, not a contract. [`scripts/sync-versions.mjs`](scripts/sync-versions.mjs) syncs whichever version fields a file already has and picks up any new directory under `plugins/` automatically — so adding a `version` to a catalog's plugin entry silently brings it into the set. A file that exists but declares no version at all is an error, so a deleted field cannot pass as "in sync".
+
+The rewrite is a surgical text replacement rather than a JSON re-serialize, so each file's formatting survives untouched. Every file is re-parsed and compared before anything is written, and nothing is written unless all of them verify.
+
 ## CI/CD
 
 Neon maintains **two** agent-skill repositories with a shared, hardened CI pipeline. Keep them aligned when you change CI/CD in either repo.
 
 | Repo | GitHub | What CI validates |
 | --- | --- | --- |
-| **agent-skills** (this repo) | [neondatabase/agent-skills](https://github.com/neondatabase/agent-skills) | Every skill under `skills/` via `skills-ref`, plus Cursor and Claude plugin manifests under `plugins/` |
+| **agent-skills** (this repo) | [neondatabase/agent-skills](https://github.com/neondatabase/agent-skills) | Every skill under `skills/` via `skills-ref` and its reference graph, plus the root Agent Plugins v1 package, both marketplace catalogs and plugin manifests, the vendored plugin skills, and every manifest version against `package.json` |
 | **neon-for-agent-platforms** | [neondatabase/neon-for-agent-platforms](https://github.com/neondatabase/neon-for-agent-platforms) | Every skill under `skills/` via `skills-ref` |
 
 Shared pipeline shape (both repos):
@@ -193,6 +237,8 @@ Shared pipeline shape (both repos):
 - Entry point: `npm run validate:ci`
 - Supply chain: SHA-pinned GitHub Actions, exact-pinned npm dependencies (`save-exact=true` in `.npmrc`, no ranges and no unpinned `npx`), `package-lock.json` resolving from `registry.npmjs.org`, `harden-runner` egress audit, Dependabot for `github-actions` + `npm`
 
-**Repo-specific (keep — do not drop when aligning):** this repo also validates the Cursor and Claude **plugin manifests** under `plugins/`. That's why `validate:ci` here is `validate:plugins && validate:skills` (vs. skills-only in `neon-for-agent-platforms`) and why this workflow also filters on `plugins/**`. Alignment means matching the shared shape above, **not** stripping this repo's plugin checks.
+**Repo-specific (keep — do not drop when aligning):** this repo also validates the root **Agent Plugins v1 package** and the Cursor and Claude **plugin manifests** under `plugins/`. That's why `validate:ci` here is `validate:agent-plugin && validate:plugins && validate:versions && validate:skills && validate:references` (vs. skills-only in `neon-for-agent-platforms`) and why this workflow also filters on `plugins/**`, `plugin.json`, `mcp.json`, `.claude-plugin/**`, and `.cursor-plugin/**`. Do not drop the last two: the catalogs hold three of the synced version fields, so losing that filter would let a catalog change skip `validate:versions`. Alignment means matching the shared shape above, **not** stripping this repo's plugin checks.
 
 **When you change CI/CD here** — workflow triggers, install hardening, `skills-ref` pinning, Dependabot config, or validate scripts — **apply the same change to [neondatabase/neon-for-agent-platforms](https://github.com/neondatabase/neon-for-agent-platforms)**, preserving each repo's intentional differences (this repo's plugin validation and `plugins/**` path filter).
+
+`neon-for-agent-platforms` has no `plugins/` directory and no root `plugin.json` yet, so `validate:agent-plugin`, `validate:versions`, and the `plugin.json`/`mcp.json` path filters do **not** port over as-is. Giving that repo its own portable manifest is a follow-up; until then, this is an intentional difference rather than drift.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,10 @@ Thanks for contributing to the Neon Agent Skills!
 
 ## Source of truth
 
-The top-level `skills/` directory is the source of truth. Plugin folders under `plugins/` ship **real copies** of the skill directories they expose (not symlinks — Cursor and Claude silently drop symlinks that escape the plugin root when a plugin is installed from git).
+The top-level `skills/` directory is the source of truth. It is consumed two different ways:
+
+- The root [`plugin.json`](plugin.json) and [`mcp.json`](mcp.json) make the repository root a portable [Agent Plugins v1](https://agent-plugins.org/specification) package that reads `skills/` in place. No vendoring, no sync step.
+- Plugin folders under `plugins/` ship **real copies** of the skill directories they expose (not symlinks — Cursor and Claude silently drop symlinks that escape the plugin root when a plugin is installed from git).
 
 Which skills each plugin vendors is declared in the `PLUGIN_SKILLS` map in [`scripts/sync-plugin-skills.mjs`](scripts/sync-plugin-skills.mjs). A value of `"*"` means "all skills under `skills/`", so new skills are vendored automatically without editing the map; you can also list specific skill names instead. To regenerate the copies after editing a skill or the map:
 
@@ -13,6 +16,17 @@ npm run sync:plugins
 ```
 
 A git pre-commit hook (installed via the `prepare` script when you run `npm install`) runs this automatically and stages the result, so you never have to copy skills by hand. CI runs `npm run validate:plugin-skills` (part of `validate:ci`) to fail the build if the vendored copies drift from the source or if any symlink sneaks back into a plugin.
+
+## Releasing
+
+`package.json` holds the plugin version, and the manifests that declare one — the root `plugin.json`, both `marketplace.json` catalogs, and each plugin's client manifest — are generated from it. Bump it and commit:
+
+```bash
+npm version patch --no-git-tag-version   # or minor / major
+git commit -am "Release the accumulated skill changes"
+```
+
+The same pre-commit hook runs `npm run sync:versions` and stages the rewritten manifests, so it only works once `npm install` has installed the hook. Don't edit those version fields by hand; the hook overwrites them from `package.json`. `npm run validate:versions` guards the invariant in CI, and `npm run sync:versions` is the fix when it fails. See `AGENTS.md` for the full field list and how `package-lock.json` fits in.
 
 ## Keep downstream marketplaces in sync
 
@@ -34,7 +48,9 @@ npm ci --ignore-scripts
 npm run validate:ci
 ```
 
-This runs skill validation (`skills-ref` on every directory under `skills/`) and plugin manifest validation under `plugins/`. See `AGENTS.md` for the full CI/CD picture and the paired **neon-for-agent-platforms** repo.
+This runs `npm run validate:agent-plugin` for the root Agent Plugins v1 package, plugin manifest validation under `plugins/`, `npm run validate:versions` to confirm every manifest matches the version in `package.json`, skill validation (`skills-ref` on every directory under `skills/`), and the skill reference-graph check. See `AGENTS.md` for the full CI/CD picture and the paired **neon-for-agent-platforms** repo.
+
+The Agent Plugins manifest schema is closed, so none of `skills`, `mcpServers`, `hooks`, or `logo` may appear in the root `plugin.json`. MCP servers are declared in the root `mcp.json` and skills are discovered from the root `skills/`; `hooks` and `logo` are client-only and belong in the packaging under `plugins/`. `AGENTS.md` lists the full set of allowed fields.
 
 ## Dependency pinning
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,12 @@ Long-running, serverless Node.js HTTP functions deployed onto your Neon branch, 
 npx skills add neondatabase/agent-skills
 ```
 
+### Agent Plugin
+
+The repository root is a portable [Agent Plugins v1](https://agent-plugins.org/specification) package, so any conforming client can install it straight from this repo. The root [`plugin.json`](plugin.json) declares the plugin, [`mcp.json`](mcp.json) declares the [Neon MCP Server](https://mcp.neon.tech), and the skills are the directories under `skills/`.
+
+The Claude Code and Cursor packaging under `plugins/` remains available for clients that expect those formats.
+
 ### Claude Code Plugin
 
 You can also install the skills as a Claude Code plugin, which bundles the Neon agent skills and the [Neon MCP Server](https://mcp.neon.tech) for natural language database management:

--- a/mcp.json
+++ b/mcp.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
+  "mcpServers": {
+    "neon": {
+      "type": "streamable-http",
+      "url": "https://mcp.neon.tech/mcp"
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@neondatabase/agent-skills",
-  "version": "1.0.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@neondatabase/agent-skills",
-      "version": "1.0.0",
+      "version": "1.1.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "prettier": "3.9.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neondatabase/agent-skills",
-  "version": "1.0.0",
+  "version": "1.1.1",
   "description": "A collection of Agent Skills for Neon",
   "license": "Apache-2.0",
   "repository": {
@@ -23,13 +23,16 @@
     "prepare": "git config core.hooksPath .githooks || true",
     "fmt": "prettier --write .",
     "sync:plugins": "node scripts/sync-plugin-skills.mjs",
+    "sync:versions": "node scripts/sync-versions.mjs",
+    "validate:agent-plugin": "node scripts/validate-agent-plugin.mjs",
     "validate:cursor-plugins": "node scripts/validate-cursor-plugins.mjs",
     "validate:claude-plugins": "node scripts/validate-claude-plugins.mjs",
     "validate:plugin-skills": "node scripts/sync-plugin-skills.mjs --check",
     "validate:plugins": "npm run validate:cursor-plugins && npm run validate:claude-plugins && npm run validate:plugin-skills",
+    "validate:versions": "node scripts/sync-versions.mjs --check",
     "validate:skills": "node scripts/validate-skills.mjs",
     "validate:references": "node scripts/check-skill-references.mjs",
-    "validate:ci": "npm run validate:plugins && npm run validate:skills && npm run validate:references"
+    "validate:ci": "npm run validate:agent-plugin && npm run validate:plugins && npm run validate:versions && npm run validate:skills && npm run validate:references"
   },
   "devDependencies": {
     "prettier": "3.9.5",

--- a/plugin.json
+++ b/plugin.json
@@ -1,5 +1,6 @@
 {
-  "name": "neon",
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "neon-postgres",
   "version": "1.1.1",
   "description": "Manage your Neon backend with the Neon agent skills and the Neon MCP Server: Lakebase Postgres, branching, Object Storage, Functions, and the AI Gateway",
   "author": {
@@ -9,7 +10,5 @@
   "homepage": "https://neon.com",
   "repository": "https://github.com/neondatabase/agent-skills",
   "license": "Apache-2.0",
-  "keywords": ["neon", "lakebase", "postgres", "serverless", "database", "mcp"],
-  "skills": "./skills/",
-  "mcpServers": "./mcp.json"
+  "keywords": ["neon", "lakebase", "postgres", "serverless", "database", "mcp"]
 }

--- a/plugins/neon-postgres/.cursor-plugin/plugin.json
+++ b/plugins/neon-postgres/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "neon-postgres",
   "displayName": "Neon Postgres",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Manage your Neon backend with the Neon agent skills and the Neon MCP Server: Lakebase Postgres, branching, Object Storage, Functions, and the AI Gateway",
   "author": {
     "name": "Neon",

--- a/scripts/sync-versions.mjs
+++ b/scripts/sync-versions.mjs
@@ -1,0 +1,327 @@
+#!/usr/bin/env node
+
+// Propagates the version in package.json into every manifest that declares
+// one. package.json is the single source of truth and the manifests are
+// generated from it, the same way plugins/*/skills is generated from skills/.
+// Releasing is therefore one edit: bump package.json and commit.
+//
+// Edits are surgical text replacements rather than a JSON re-serialize, so
+// each file's existing formatting survives byte for byte. Every rewrite is
+// re-parsed and compared against the expected result, and nothing is written
+// until all of them verify, so a stray match cannot corrupt a file.
+//
+// package-lock.json also carries the version, but it repeats "version" for
+// every dependency, which makes it unsafe to rewrite by text match. npm owns
+// it, so it is checked and never written; the fix is to run npm version.
+//
+// Every path rewritten is printed to stdout, one per line, so the pre-commit
+// hook can stage exactly those. Apart from the version field these files are
+// hand-authored, so staging them wholesale would sweep an unstaged edit into
+// someone's commit. Status goes to stderr.
+//
+// Usage:
+//   node scripts/sync-versions.mjs           # write versions
+//   node scripts/sync-versions.mjs --check    # verify versions, no writes
+
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+// The suggested pattern from https://semver.org.
+const SEMVER_PATTERN =
+  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/;
+
+const SOURCE = "package.json";
+const LOCKFILE = "package-lock.json";
+const CATALOGS = [
+  ".claude-plugin/marketplace.json",
+  ".cursor-plugin/marketplace.json",
+];
+const CLIENT_MANIFESTS = [
+  ".claude-plugin/plugin.json",
+  ".cursor-plugin/plugin.json",
+];
+
+const repoRoot = process.cwd();
+const checkMode = process.argv.includes("--check");
+const problems = [];
+const writes = [];
+// Set when a problem is one that a write-mode run would actually repair, so
+// the "run sync:versions" hint never appears next to a problem it cannot fix.
+let hasStaleManifest = false;
+
+function fail(message) {
+  problems.push(message);
+}
+
+function isPlainObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+// A missing file is skipped. Which packaging formats a repo ships is not this
+// script's business, and the validators already require the ones that matter.
+// Anything else - an unreadable file, a bad mode - is a real failure, and
+// swallowing it would report a file this script never read as in sync.
+async function readFileOrNull(relativePath) {
+  try {
+    return await fs.readFile(path.join(repoRoot, relativePath), "utf8");
+  } catch (error) {
+    if (error.code === "ENOENT" || error.code === "ENOTDIR") {
+      return null;
+    }
+    throw error;
+  }
+}
+
+function getAt(data, pointer) {
+  return pointer.reduce(
+    (node, key) => (node == null ? undefined : node[key]),
+    data,
+  );
+}
+
+function setAt(data, pointer, value) {
+  const parent = pointer.slice(0, -1).reduce((node, key) => node[key], data);
+  parent[pointer[pointer.length - 1]] = value;
+}
+
+function formatPointer(pointer) {
+  return pointer
+    .map((key, index) => {
+      // The lockfile's own entry is keyed by the empty string, which would
+      // otherwise print as "packages..version".
+      if (typeof key === "number" || !/^[A-Za-z_$][\w$]*$/.test(key)) {
+        return `[${JSON.stringify(key)}]`;
+      }
+      return index === 0 ? key : `.${key}`;
+    })
+    .join("");
+}
+
+// Every version a packaging format declares for the plugin. A catalog carries
+// one for the catalog itself and one per plugin entry; a lockfile repeats the
+// package's own version in two places.
+function versionPointers(data, kind) {
+  if (!isPlainObject(data)) {
+    return [];
+  }
+
+  const pointers = [];
+  if (kind === "catalog") {
+    if (isPlainObject(data.metadata) && data.metadata.version !== undefined) {
+      pointers.push(["metadata", "version"]);
+    }
+    if (Array.isArray(data.plugins)) {
+      data.plugins.forEach((entry, index) => {
+        if (isPlainObject(entry) && entry.version !== undefined) {
+          pointers.push(["plugins", index, "version"]);
+        }
+      });
+    }
+    return pointers;
+  }
+
+  if (data.version !== undefined) {
+    pointers.push(["version"]);
+  }
+  if (
+    kind === "lockfile" &&
+    isPlainObject(data.packages) &&
+    isPlainObject(data.packages[""]) &&
+    data.packages[""].version !== undefined
+  ) {
+    pointers.push(["packages", "", "version"]);
+  }
+  return pointers;
+}
+
+function describeStale(data, stale) {
+  return stale
+    .map(
+      (pointer) =>
+        `${formatPointer(pointer)} = ${JSON.stringify(getAt(data, pointer))}`,
+    )
+    .join(", ");
+}
+
+async function planFile(relativePath, kind, version) {
+  let original;
+  try {
+    original = await readFileOrNull(relativePath);
+  } catch (error) {
+    fail(`${relativePath} could not be read: ${error.message}`);
+    return;
+  }
+  if (original === null) {
+    return;
+  }
+
+  let data;
+  try {
+    data = JSON.parse(original);
+  } catch (error) {
+    fail(`${relativePath} is not valid JSON: ${error.message}`);
+    return;
+  }
+
+  const pointers = versionPointers(data, kind);
+  if (pointers.length === 0) {
+    // Skipping silently would let a deleted field pass as "in sync" forever.
+    fail(
+      `${relativePath} exists but declares no version. Add one, or drop the file if the packaging is gone.`,
+    );
+    return;
+  }
+
+  const stale = pointers.filter((pointer) => getAt(data, pointer) !== version);
+  if (stale.length === 0) {
+    return;
+  }
+
+  // npm owns the lockfile, and its per-dependency "version" fields make a
+  // text rewrite unsafe, so report it instead of touching it.
+  if (kind === "lockfile") {
+    fail(
+      `${relativePath} declares ${describeStale(data, stale)}, expected "${version}". npm owns this file; run: npm install --ignore-scripts`,
+    );
+    return;
+  }
+
+  if (checkMode) {
+    hasStaleManifest = true;
+    fail(
+      `${relativePath} declares ${describeStale(data, stale)}, expected "${version}".`,
+    );
+    return;
+  }
+
+  // Match on the value currently in the file, so an unrelated nested
+  // "version" holding something else is never touched.
+  let updated = original;
+  for (const current of new Set(
+    stale.map((pointer) => JSON.stringify(getAt(data, pointer))),
+  )) {
+    const pattern = new RegExp(
+      `("version"\\s*:\\s*)${escapeRegExp(current)}`,
+      "g",
+    );
+    updated = updated.replace(pattern, `$1${JSON.stringify(version)}`);
+  }
+  if (updated === original) {
+    fail(
+      `${relativePath}: could not find the version literal in the file text. Update it by hand.`,
+    );
+    return;
+  }
+
+  const expected = JSON.parse(original);
+  for (const pointer of pointers) {
+    setAt(expected, pointer, version);
+  }
+  let actual;
+  try {
+    actual = JSON.parse(updated);
+  } catch (error) {
+    fail(`${relativePath}: rewriting the version broke the JSON. ${error}`);
+    return;
+  }
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+    fail(
+      `${relativePath}: rewriting the version would have changed another field. Update this file by hand.`,
+    );
+    return;
+  }
+
+  writes.push({ relativePath, contents: updated });
+}
+
+// Walks plugins/ rather than resolving each catalog's "source", so a plugin
+// directory not listed in a catalog yet is still kept in step.
+async function pluginManifests() {
+  let entries;
+  try {
+    entries = await fs.readdir(path.join(repoRoot, "plugins"), {
+      withFileTypes: true,
+    });
+  } catch {
+    return [];
+  }
+
+  const manifests = [];
+  for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
+    if (entry.isDirectory()) {
+      for (const manifest of CLIENT_MANIFESTS) {
+        manifests.push(`plugins/${entry.name}/${manifest}`);
+      }
+    }
+  }
+  return manifests;
+}
+
+async function main() {
+  const raw = await readFileOrNull(SOURCE);
+  if (raw === null) {
+    throw new Error(
+      `${SOURCE} is missing; it holds the version every manifest derives from.`,
+    );
+  }
+
+  let version;
+  try {
+    version = JSON.parse(raw).version;
+  } catch (error) {
+    throw new Error(`${SOURCE} is not valid JSON: ${error.message}`);
+  }
+  if (typeof version !== "string" || !SEMVER_PATTERN.test(version)) {
+    throw new Error(
+      `${SOURCE} "version" must be a semantic version, got ${JSON.stringify(version)}.`,
+    );
+  }
+
+  await planFile(LOCKFILE, "lockfile", version);
+  await planFile("plugin.json", "manifest", version);
+  for (const catalog of CATALOGS) {
+    await planFile(catalog, "catalog", version);
+  }
+  for (const manifest of await pluginManifests()) {
+    await planFile(manifest, "manifest", version);
+  }
+
+  // Nothing is written unless every file verified, so a rejected rewrite
+  // cannot leave the tree half-updated.
+  if (problems.length > 0) {
+    process.stderr.write(
+      checkMode
+        ? `Versions are out of sync with ${SOURCE}:\n`
+        : "Version sync failed:\n",
+    );
+    for (const problem of problems) {
+      process.stderr.write(`- ${problem}\n`);
+    }
+    if (checkMode && hasStaleManifest) {
+      process.stderr.write("Run: npm run sync:versions\n");
+    }
+    process.exit(1);
+  }
+
+  for (const { relativePath, contents } of writes) {
+    await fs.writeFile(path.join(repoRoot, relativePath), contents);
+    process.stderr.write(`Set ${relativePath} to ${version}\n`);
+    process.stdout.write(`${relativePath}\n`);
+  }
+
+  process.stderr.write(
+    checkMode
+      ? `Versions are in sync at ${version}.\n`
+      : `Versions synced to ${version}.\n`,
+  );
+}
+
+main().catch((error) => {
+  process.stderr.write(`${error.message}\n`);
+  process.exit(1);
+});

--- a/scripts/validate-agent-plugin.mjs
+++ b/scripts/validate-agent-plugin.mjs
@@ -1,0 +1,589 @@
+#!/usr/bin/env node
+
+// Validates the repo root as an Agent Plugins v1.0.0 portable package:
+// the root plugin.json manifest, the optional root mcp.json, and the skill
+// discovery rules for skills/. The client-specific packaging under plugins/
+// is a compatibility layer and is validated separately.
+//
+// Spec: https://agent-plugins.org/specification
+
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+const SPEC_VERSION = "1.0.0";
+const SCHEMA_BASE = `https://agent-plugins.org/schemas/${SPEC_VERSION}`;
+const PLUGIN_SCHEMA = `${SCHEMA_BASE}/plugin.schema.json`;
+const MCP_SCHEMA = `${SCHEMA_BASE}/mcp.schema.json`;
+
+// Names are 1-64 chars, lowercase alphanumerics with hyphens and periods,
+// bounded by alphanumerics, and may not contain "--" or "..".
+const NAME_PATTERN = /^(?!.*(?:--|\.\.))[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?$/;
+const NAMESPACE_PATTERN = /^[a-z0-9]+(?:[.-][a-z0-9]+)+$/i;
+const CWD_PATTERN =
+  /^(?:\.\/|\$\{PLUGIN_ROOT\}(?:\/|$)|\$\{PLUGIN_DATA\}(?:\/|$))/;
+// RFC 9110 field name (token) and field value (visible ASCII, space, tab).
+const HEADER_NAME_PATTERN = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/;
+const HEADER_VALUE_PATTERN = /^[\t\x20-\x7e\x80-\xff]*$/;
+
+const MANIFEST_FIELDS = new Set([
+  "$schema",
+  "name",
+  "version",
+  "description",
+  "author",
+  "homepage",
+  "repository",
+  "license",
+  "keywords",
+  "extensions",
+]);
+const STRING_FIELDS = [
+  "version",
+  "description",
+  "homepage",
+  "repository",
+  "license",
+];
+const AUTHOR_FIELDS = new Set(["name", "email", "url"]);
+const RESERVED_ENV = new Set(["PLUGIN_ROOT", "PLUGIN_DATA"]);
+
+const TRANSPORTS = {
+  stdio: {
+    required: ["type", "command"],
+    allowed: ["type", "command", "args", "env", "cwd"],
+  },
+  "streamable-http": {
+    required: ["type", "url"],
+    allowed: ["type", "url", "headers"],
+  },
+  sse: {
+    required: ["type", "url"],
+    allowed: ["type", "url", "headers"],
+  },
+};
+
+const repoRoot = process.cwd();
+const errors = [];
+
+function addError(message) {
+  errors.push(message);
+}
+
+function isPlainObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+// True when a plugin-relative or ${PLUGIN_*}-rooted path climbs out of its
+// root once "." and ".." segments are collapsed.
+function escapesRoot(value) {
+  const rooted = value.replace(/^\$\{PLUGIN_(?:ROOT|DATA)\}\/?/, "");
+  const normalized = path.posix.normalize(rooted.replace(/\\/g, "/"));
+  return normalized === ".." || normalized.startsWith("../");
+}
+
+// §4.1 requires containment of the *filesystem-resolved* path, so a lexical
+// check alone would miss a symlink pointing outside. Resolve bundled paths
+// that exist on disk; anything absent can only be checked lexically.
+async function escapesRootOnDisk(value) {
+  if (value.startsWith("${PLUGIN_DATA}")) {
+    // PLUGIN_DATA is a client-managed directory outside the package.
+    return false;
+  }
+  const relative = value.replace(/^\$\{PLUGIN_ROOT\}\/?/, "");
+  try {
+    const root = await fs.realpath(repoRoot);
+    const resolved = await fs.realpath(path.resolve(root, relative));
+    return resolved !== root && !resolved.startsWith(root + path.sep);
+  } catch {
+    return false;
+  }
+}
+
+function isLoopback(hostname) {
+  return (
+    hostname === "localhost" ||
+    hostname === "[::1]" ||
+    /^127\.\d+\.\d+\.\d+$/.test(hostname)
+  );
+}
+
+async function readJsonFile(filePath, context) {
+  let stat;
+  try {
+    stat = await fs.lstat(filePath);
+  } catch {
+    return { found: false };
+  }
+  if (!stat.isFile()) {
+    // Stricter than §4.1, which allows a symlink that stays inside the
+    // package. Kept deliberately: this repo bans symlinks in distributed
+    // packaging because Cursor and Claude silently drop them on install.
+    const relative = path.relative(repoRoot, filePath);
+    addError(`${context} must be a regular file: ${relative}`);
+    return { found: true };
+  }
+
+  try {
+    return {
+      found: true,
+      data: JSON.parse(await fs.readFile(filePath, "utf8")),
+    };
+  } catch (error) {
+    addError(`${context} could not be read as JSON: ${error.message}`);
+    return { found: true };
+  }
+}
+
+function validateManifest(manifest) {
+  if (!isPlainObject(manifest)) {
+    addError("plugin.json must be a JSON object.");
+    return;
+  }
+
+  if (manifest.$schema !== PLUGIN_SCHEMA) {
+    addError(`plugin.json: "$schema" must be "${PLUGIN_SCHEMA}".`);
+  }
+
+  if (typeof manifest.name !== "string") {
+    addError('plugin.json: "name" is required and must be a string.');
+  } else if (manifest.name.length > 64 || !NAME_PATTERN.test(manifest.name)) {
+    addError(
+      `plugin.json: "name" must be 1-64 lowercase alphanumerics, hyphens, or periods bounded by alphanumerics, with no "--" or "..": "${manifest.name}"`,
+    );
+  }
+
+  // The v1 manifest schema is closed. Client fields such as "skills",
+  // "mcpServers", or "hooks" belong in mcp.json or an extension namespace.
+  for (const field of Object.keys(manifest)) {
+    if (!MANIFEST_FIELDS.has(field)) {
+      addError(
+        `plugin.json: "${field}" is not an allowed top-level field. Use "extensions" for client-specific data.`,
+      );
+    }
+  }
+
+  for (const field of STRING_FIELDS) {
+    if (field in manifest && typeof manifest[field] !== "string") {
+      addError(`plugin.json: "${field}" must be a string.`);
+    }
+  }
+
+  if ("author" in manifest) {
+    const { author } = manifest;
+    if (!isPlainObject(author)) {
+      addError('plugin.json: "author" must be an object.');
+    } else {
+      for (const field of Object.keys(author)) {
+        if (!AUTHOR_FIELDS.has(field)) {
+          addError(`plugin.json: "author.${field}" is not an allowed field.`);
+        } else if (typeof author[field] !== "string") {
+          addError(`plugin.json: "author.${field}" must be a string.`);
+        }
+      }
+    }
+  }
+
+  if ("keywords" in manifest) {
+    const { keywords } = manifest;
+    const valid =
+      Array.isArray(keywords) && keywords.every((k) => typeof k === "string");
+    if (!valid) {
+      addError('plugin.json: "keywords" must be an array of strings.');
+    }
+  }
+
+  if ("extensions" in manifest) {
+    const { extensions } = manifest;
+    if (!isPlainObject(extensions)) {
+      addError('plugin.json: "extensions" must be an object.');
+    } else {
+      for (const [namespace, value] of Object.entries(extensions)) {
+        if (!NAMESPACE_PATTERN.test(namespace)) {
+          addError(
+            `plugin.json: extension namespace "${namespace}" must be a reverse-domain identifier such as "com.vendor.client".`,
+          );
+        }
+        if (!isPlainObject(value)) {
+          addError(
+            `plugin.json: extension "${namespace}" must map to an object.`,
+          );
+        }
+      }
+    }
+  }
+}
+
+function validateServerUrl(name, url) {
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    addError(`mcp.json: server "${name}" has an invalid "url": "${url}"`);
+    return;
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    addError(`mcp.json: server "${name}" requires an http or https "url".`);
+    return;
+  }
+  if (parsed.username || parsed.password) {
+    addError(`mcp.json: server "${name}" must not embed credentials in "url".`);
+  }
+  if (parsed.hash) {
+    addError(`mcp.json: server "${name}" must not put a fragment in "url".`);
+  }
+  if (parsed.protocol !== "https:" && !isLoopback(parsed.hostname)) {
+    addError(
+      `mcp.json: server "${name}" must use HTTPS for a non-loopback URL.`,
+    );
+  }
+}
+
+// §7.2.1: command MUST be either a bare executable name or a plugin-relative
+// path beginning with "./". Absolute paths are neither form.
+async function validateCommand(name, command) {
+  if (command.startsWith("./")) {
+    // A plugin-relative path is a single token even when it contains spaces,
+    // so only containment matters here.
+    if (escapesRoot(command) || (await escapesRootOnDisk(command))) {
+      addError(
+        `mcp.json: server "${name}" has a "command" that escapes the plugin: "${command}"`,
+      );
+    }
+    return;
+  }
+  if (/\s/.test(command)) {
+    addError(
+      `mcp.json: server "${name}" has "command" with whitespace. Use one executable token and pass the rest via "args".`,
+    );
+    return;
+  }
+  if (/[\\/]/.test(command)) {
+    addError(
+      `mcp.json: server "${name}" has "command" path "${command}". Use a bare executable name or a plugin-relative path beginning with "./".`,
+    );
+  }
+}
+
+function validateEnv(name, env) {
+  if (!isPlainObject(env)) {
+    addError(`mcp.json: server "${name}" requires "env" to be an object.`);
+    return;
+  }
+  for (const [key, value] of Object.entries(env)) {
+    if (RESERVED_ENV.has(key)) {
+      addError(
+        `mcp.json: server "${name}" must not set the reserved env variable "${key}".`,
+      );
+    }
+    if (typeof value !== "string") {
+      addError(`mcp.json: server "${name}" env "${key}" must be a string.`);
+    }
+  }
+}
+
+function validateHeaders(name, headers) {
+  if (!isPlainObject(headers)) {
+    addError(`mcp.json: server "${name}" requires "headers" to be an object.`);
+    return;
+  }
+  const seen = new Set();
+  for (const [key, value] of Object.entries(headers)) {
+    const lower = key.toLowerCase();
+    if (seen.has(lower)) {
+      addError(
+        `mcp.json: server "${name}" repeats header "${key}" under a different casing.`,
+      );
+    }
+    seen.add(lower);
+    if (!HEADER_NAME_PATTERN.test(key)) {
+      addError(
+        `mcp.json: server "${name}" header "${key}" is not a valid HTTP header name.`,
+      );
+    }
+    if (typeof value !== "string") {
+      addError(`mcp.json: server "${name}" header "${key}" must be a string.`);
+    } else if (!HEADER_VALUE_PATTERN.test(value)) {
+      addError(
+        `mcp.json: server "${name}" header "${key}" has a value that is not a valid HTTP field value.`,
+      );
+    }
+  }
+}
+
+async function validateServerFields(name, server) {
+  if ("args" in server) {
+    const { args } = server;
+    const valid =
+      Array.isArray(args) && args.every((a) => typeof a === "string");
+    if (!valid) {
+      addError(
+        `mcp.json: server "${name}" requires "args" to be an array of strings.`,
+      );
+    }
+  }
+
+  if ("env" in server) {
+    validateEnv(name, server.env);
+  }
+
+  if ("cwd" in server) {
+    const { cwd } = server;
+    if (typeof cwd !== "string" || !CWD_PATTERN.test(cwd)) {
+      addError(
+        `mcp.json: server "${name}" requires "cwd" to start with "./", "\${PLUGIN_ROOT}", or "\${PLUGIN_DATA}".`,
+      );
+    } else if (escapesRoot(cwd) || (await escapesRootOnDisk(cwd))) {
+      addError(
+        `mcp.json: server "${name}" has a "cwd" that escapes the plugin: "${cwd}"`,
+      );
+    }
+  }
+
+  if ("headers" in server) {
+    validateHeaders(name, server.headers);
+  }
+}
+
+async function validateMcp(config) {
+  if (!isPlainObject(config)) {
+    addError("mcp.json must be a JSON object.");
+    return;
+  }
+
+  if (config.$schema !== MCP_SCHEMA) {
+    addError(
+      `mcp.json: "$schema" must be "${MCP_SCHEMA}" so the MCP configuration targets the same Agent Plugins version as plugin.json.`,
+    );
+  }
+  for (const field of Object.keys(config)) {
+    if (field !== "$schema" && field !== "mcpServers") {
+      addError(`mcp.json: "${field}" is not an allowed top-level field.`);
+    }
+  }
+
+  const servers = config.mcpServers;
+  if (!isPlainObject(servers)) {
+    addError('mcp.json: "mcpServers" is required and must be an object.');
+    return;
+  }
+
+  for (const [name, server] of Object.entries(servers)) {
+    if (!isPlainObject(server)) {
+      addError(`mcp.json: server "${name}" must be an object.`);
+      continue;
+    }
+
+    // Own-property lookup: "constructor" and friends are truthy on a plain
+    // object and would sail past this guard into a crash below.
+    const transport = Object.hasOwn(TRANSPORTS, server.type)
+      ? TRANSPORTS[server.type]
+      : undefined;
+    if (!transport) {
+      addError(
+        `mcp.json: server "${name}" has type "${server.type}". Use "stdio", "streamable-http", or "sse".`,
+      );
+      continue;
+    }
+
+    for (const field of transport.required) {
+      if (typeof server[field] !== "string" || server[field].length === 0) {
+        addError(`mcp.json: server "${name}" requires a non-empty "${field}".`);
+      }
+    }
+    for (const field of Object.keys(server)) {
+      if (!transport.allowed.includes(field)) {
+        addError(
+          `mcp.json: server "${name}" (${server.type}) does not allow "${field}".`,
+        );
+      }
+    }
+
+    await validateServerFields(name, server);
+
+    if (server.type === "stdio") {
+      if (typeof server.command === "string") {
+        await validateCommand(name, server.command);
+      }
+    } else if (typeof server.url === "string") {
+      validateServerUrl(name, server.url);
+    }
+  }
+}
+
+// Unwraps a YAML scalar the way a real parser would, so a quoted name or a
+// trailing comment does not disagree with skills-ref over the same file.
+function parseScalar(raw) {
+  const value = raw.trim();
+  const quote = value[0];
+  if (quote === '"' || quote === "'") {
+    const closing = value.indexOf(quote, 1);
+    if (closing !== -1) {
+      return value.slice(1, closing);
+    }
+  }
+  const comment = value.search(/\s#/);
+  return comment === -1 ? value : value.slice(0, comment).trim();
+}
+
+function parseFrontmatter(content) {
+  const normalized = content.replace(/\r\n/g, "\n");
+  if (!normalized.startsWith("---\n")) {
+    return null;
+  }
+  const closingIndex = normalized.indexOf("\n---\n", 4);
+  if (closingIndex === -1) {
+    return null;
+  }
+
+  const fields = {};
+  for (const line of normalized.slice(4, closingIndex).split("\n")) {
+    const trimmed = line.trimStart();
+    const separator = line.indexOf(":");
+    // Skip comments and indented lines so only top-level keys are collected.
+    if (separator === -1 || trimmed !== line || trimmed.startsWith("#")) {
+      continue;
+    }
+    fields[line.slice(0, separator).trim()] = parseScalar(
+      line.slice(separator + 1),
+    );
+  }
+  return fields;
+}
+
+async function validateSkill(skillsRoot, name) {
+  // Only immediate children of skills/ are discovered.
+  const skillFile = path.join(skillsRoot, name, "SKILL.md");
+  let stat;
+  try {
+    stat = await fs.lstat(skillFile);
+  } catch {
+    addError(`skills/${name} is missing a SKILL.md file.`);
+    return;
+  }
+  if (!stat.isFile()) {
+    addError(`skills/${name}/SKILL.md must be a regular file.`);
+    return;
+  }
+
+  const frontmatter = parseFrontmatter(await fs.readFile(skillFile, "utf8"));
+  if (!frontmatter) {
+    addError(`skills/${name}/SKILL.md is missing YAML frontmatter.`);
+    return;
+  }
+  if (frontmatter.name !== name) {
+    addError(
+      `skills/${name}/SKILL.md declares name "${frontmatter.name ?? ""}", which must match its directory.`,
+    );
+  }
+  if (!frontmatter.description) {
+    addError(`skills/${name}/SKILL.md is missing a "description".`);
+  }
+}
+
+// §4.1 requires every path in the package to resolve inside it. The caller
+// rejects a symlinked skill directory outright; a nested symlink is legal so
+// long as it stays contained, so those are resolved rather than banned.
+//
+// Resolves here rather than through escapesRootOnDisk, which reports an
+// unresolvable path as contained. That is right for the MCP command and cwd
+// callers, which may name paths that do not exist until the server runs, but
+// here it would pass a link whose containment was never established.
+async function validateSkillContainment(dir, root) {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const entryPath = path.join(dir, entry.name);
+    if (entry.isSymbolicLink()) {
+      const relative = path.relative(repoRoot, entryPath);
+      let resolved;
+      try {
+        resolved = await fs.realpath(entryPath);
+      } catch {
+        addError(
+          `${relative} is a symlink that does not resolve, so it cannot be shown to stay inside the plugin.`,
+        );
+        continue;
+      }
+      if (resolved !== root && !resolved.startsWith(root + path.sep)) {
+        addError(`${relative} is a symlink that resolves outside the plugin.`);
+      }
+      continue;
+    }
+    if (entry.isDirectory()) {
+      await validateSkillContainment(entryPath, root);
+    }
+  }
+}
+
+async function validateSkills() {
+  const skillsRoot = path.join(repoRoot, "skills");
+  let rootStat;
+  try {
+    rootStat = await fs.lstat(skillsRoot);
+  } catch {
+    // A plugin without skills is valid; it just exposes nothing portable here.
+    return;
+  }
+  if (!rootStat.isDirectory()) {
+    addError("skills exists at the plugin root but is not a directory.");
+    return;
+  }
+
+  // Resolved once: every nested symlink is compared against it.
+  const root = await fs.realpath(repoRoot);
+  const entries = await fs.readdir(skillsRoot, { withFileTypes: true });
+  for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
+    if (entry.isSymbolicLink()) {
+      addError(
+        `skills/${entry.name} is a symlink; commit a real directory instead.`,
+      );
+      continue;
+    }
+    if (!entry.isDirectory()) {
+      continue;
+    }
+    // Stricter than §7.1, which ignores a child directory without a SKILL.md.
+    // Kept deliberately: validate-skills.mjs runs skills-ref over every child
+    // of skills/, so such a directory already fails CI. Staying silent here
+    // would imply it is fine.
+    await validateSkill(skillsRoot, entry.name);
+    await validateSkillContainment(path.join(skillsRoot, entry.name), root);
+  }
+}
+
+async function main() {
+  const manifest = await readJsonFile(
+    path.join(repoRoot, "plugin.json"),
+    "Agent Plugins manifest",
+  );
+  if (!manifest.found) {
+    addError("plugin.json is missing from the repository root.");
+  } else if (manifest.data !== undefined) {
+    validateManifest(manifest.data);
+  }
+
+  // mcp.json is optional; validate it only when the plugin ships MCP servers.
+  const mcp = await readJsonFile(
+    path.join(repoRoot, "mcp.json"),
+    "Agent Plugins MCP configuration",
+  );
+  if (mcp.data !== undefined) {
+    await validateMcp(mcp.data);
+  }
+
+  await validateSkills();
+
+  if (errors.length > 0) {
+    console.error("Agent Plugins validation failed:");
+    for (const error of errors) {
+      console.error(`- ${error}`);
+    }
+    process.exit(1);
+  }
+  console.log(`Agent Plugins v${SPEC_VERSION} validation passed.`);
+}
+
+main().catch((error) => {
+  process.stderr.write(`${error.message}\n`);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Adds a root `plugin.json` and `mcp.json` so this repository is itself a conforming [Agent Plugins v1](https://agent-plugins.org/specification) package, installable by any client that implements the spec. The portable package reads the top-level `skills/` in place, so it needs no vendoring and no sync step.

Releases the result as **1.1.1**, and makes `package.json` the single source of truth for that number so the six places it is declared are generated rather than hand-maintained.

Apart from that version bump, nothing under `plugins/` changes, so Claude Code and Cursor installs behave exactly as before.

### Why the client manifests can't just be reused

The v1 manifest schema is closed (`additionalProperties: false`). The `skills`, `mcpServers`, `logo`, and `displayName` fields our existing manifests carry are nonconforming at the top level, and MCP configuration must live in its own `mcp.json`. So the root manifest is a new file rather than a copy.

### The two `mcp.json` files are intentionally different

| File | Transport | Consumer |
| --- | --- | --- |
| `mcp.json` (new, root) | `streamable-http` | Agent Plugins v1 clients |
| `plugins/neon-postgres/mcp.json` (unchanged) | `http` | Claude Code, Cursor |

Same transport, same endpoint — only the config vocabulary differs. The v1 schema accepts `stdio`, `streamable-http`, or `sse` and would reject `http`. I confirmed `https://mcp.neon.tech/mcp` serves Streamable HTTP: an unauthenticated `initialize` POST returns the MCP OAuth challenge (`www-authenticate: Bearer ... resource_metadata=...`) rather than a 404 or 405.

### Artifact mapping

| Artifact | Destination |
| --- | --- |
| Plugin identity/metadata | Portable core — new root `plugin.json` |
| Neon MCP server | Portable core — new root `mcp.json` |
| 8 skills under `skills/` | Portable core — already conforming, read in place |
| `.claude-plugin/` + `.cursor-plugin/` manifests | Compatibility layer — version bump only |
| Vendored skill copies under `plugins/` | Compatibility layer — unchanged |
| Both `marketplace.json` catalogs | Distribution metadata — version bump only |

Hooks, agents, commands, and LSP servers are not portable v1 components and stay in the client packaging. The two `marketplace.json` catalogs also stay where Claude Code and Cursor look for them, at the repo root.

### Release: one source of truth

The root manifest added a sixth place the version is declared, and nothing kept them in step. A bump that missed one would publish a catalog entry advertising a different version than the plugin it installs.

Rather than validate six hand-maintained copies, `package.json` now **owns** the version and the rest are generated from it — the same relationship `skills/` already has with `plugins/*/skills`:

| Generated file | Field |
| --- | --- |
| `plugin.json` | `version` |
| `.claude-plugin/marketplace.json` | `metadata.version`, `plugins[].version` |
| `.cursor-plugin/marketplace.json` | `metadata.version` |
| `plugins/neon-postgres/.claude-plugin/plugin.json` | `version` |
| `plugins/neon-postgres/.cursor-plugin/plugin.json` | `version` |

`package-lock.json` carries the version twice as well, but it repeats `"version"` for every dependency, which makes a text rewrite unsafe. npm owns that file, so the script **checks it and never writes it**, pointing you at `npm install` when it drifts.

A release is one edit:

```bash
npm version patch --no-git-tag-version
git commit -am "Release ..."
```

`scripts/sync-versions.mjs` does the propagation and the pre-commit hook runs it alongside the existing `sync-plugin-skills.mjs`, staging **only the files it rewrote**. The script prints those paths, so an unrelated in-progress edit inside a manifest is never swept into your commit. `npm run validate:versions` is that same script in `--check` mode, wired into `validate:ci`, so a hand-edited manifest or a commit made with `--no-verify` still fails the build.

Three implementation details worth a look in review:

- It rewrites the version as a **surgical text replacement**, not a JSON re-serialize, so each manifest keeps its existing formatting. A `JSON.stringify` round-trip would reflow files Prettier and the repo already disagree about, burying the change in noise.
- It re-parses every file it would rewrite and compares against the expected object, refusing to write if anything but a version field would change. Writes are **all-or-nothing**, so a refusal on the fourth file cannot leave the first three rewritten — verified with a fixture where an unrelated nested `version` shares the old value.
- A file that exists but declares **no** version is an error rather than a silent pass. Deriving the field list from what happens to be present would otherwise let a deleted `version` read as "in sync" forever.

`package.json` moves `1.0.0` → `1.1.1` to adopt the plugin's release line. It is unpublished (no `npm publish`, no `NPM_TOKEN` anywhere in the repo), so nothing outside this repo consumed the old number.

### Validation

`scripts/validate-agent-plugin.mjs` gates the new manifests. It is dependency-free and hand-rolled to match the sibling validators. It enforces the closed manifest field set and name rules, MCP transport variants with `command`/`cwd` containment (including symlink resolution) and HTTP header validity, and skill discovery.

Two details worth calling out:

- It shares `skills-ref`'s frontmatter semantics — quoted names and trailing comments are unwrapped — so the two validators in the same CI run cannot disagree about the same `SKILL.md`.
- Containment is checked all the way down a skill, not just at its root. A symlink nested inside a skill that resolves outside the repo would otherwise be shipped to a v1 client, since the portable package reads `skills/` in place.

### Drive-by fix

`.claude-plugin/**` and `.cursor-plugin/**` were missing from the workflow path filters, so editing a marketplace catalog skipped CI even though `validate:plugins` reads it. Added alongside the new `plugin.json`/`mcp.json` filters.

## Review round

Three review passes found eight real defects, all fixed in this branch and each verified by reproducing the failure first:

| Defect | Consequence | Fix |
| --- | --- | --- |
| `package-lock.json` left at `1.0.0` | The one file next to `package.json` that the "single source of truth" claim didn't reach | Synced, and now covered by `validate:versions` |
| `sync-versions.mjs` no-oped on a deleted `version` field | `--check` reported "in sync" for a manifest with no version at all | Missing field is now an error |
| Hook's `git add` globs aborted on no match | `fatal: pathspec ... did not match any files` (exit 128) would block every commit the first time a plugin shipped without one of the two client formats | Both staging loops now skip paths that do not exist |
| `TRANSPORTS[server.type]` matched `Object.prototype` keys | `"type": "constructor"` crashed with `transport.required is not iterable`, skipping all skill validation in that run | `Object.hasOwn` lookup |
| `--check` appended `Run: npm run sync:versions` to every failure | It contradicted the correct remedy printed one line above it for lockfile drift, and named a command that cannot restore a deleted `version` field either | Hint is withheld unless some problem is a writable stale manifest; `AGENTS.md` now names the fix per failure mode |
| `readFileOrNull` swallowed every error, not just `ENOENT` | A manifest that could not be read reported "in sync" with exit 0 | Only `ENOENT`/`ENOTDIR` count as absence; anything else is reported with its path |
| `escapesRootOnDisk` reports an unresolvable path as contained | A dangling symlink inside a skill passed containment silently | Skill containment resolves directly and reports links it cannot resolve. The permissive fallback stays for the MCP `command`/`cwd` callers, which may name paths that do not exist until the server runs |
| Hook staged all five manifests on **every** commit | These files are hand-authored apart from the version field, so an in-progress edit to a description or keyword list would be committed silently — content the author never staged. A regression against `main`, whose hook only staged generated skill copies | The script prints the paths it rewrote and the hook stages only those |

Two notes from that list:

- The lockfile fix needed more than `npm version`: a later `npx` invocation silently restored `1.0.0` from a stale `node_modules/.package-lock.json`. `npm install --ignore-scripts` reconciles both, and that is what the new check tells you to run. The drift was caught by the check added in this same PR.
- The staging fix narrows the window rather than closing it completely. A manifest that carries both a hand edit and a version bump in the same commit is still staged whole-file, because git stages files, not lines. That now only happens on a release commit touching that same file, instead of on every commit.

## Test plan

- [x] `npm run validate:ci` passes all five stages, and CI is green on the exact head commit
- [x] `npm ci --ignore-scripts` resolves against the corrected lockfile (this is what CI runs)
- [x] All 8 version fields — the 6 generated ones plus both in `package-lock.json` — confirmed at `1.1.1`
- [x] New and changed files introduce no Prettier regressions (the four **changed** files Prettier flags all already failed at `main`; Prettier is not a CI gate)
- [x] Root `plugin.json` and `mcp.json` verified against the published v1 JSON Schemas
- [x] `validate-agent-plugin.mjs` exercised against ~40 fixtures covering manifest, MCP transport, containment, header, and skill-discovery violations, plus positive controls
- [x] `sync-versions.mjs` exercised against fixtures: non-semver source, missing source, no manifests, stale manifest in `--check` mode, deleted version field, stale lockfile, an unrelated nested `version` left alone, and an unrelated nested `version` sharing the old value (refused, tree untouched)
- [x] Symlink containment: an escaping symlink nested inside a skill is rejected, a dangling one is reported, a contained one is allowed
- [x] Remedy hints: lockfile-only drift and a missing `version` field print no `sync:versions` hint; a stale manifest still does, including when mixed with a lockfile failure
- [x] An unreadable (`chmod 000`) manifest is reported with its path instead of counted as in sync
- [x] Pre-commit hook completes a commit in a fixture repo whose plugin has no `.cursor-plugin/`, and in one with an empty `plugins/` — both aborted with a pathspec error before
- [x] Hook staging, in a throwaway repo built from this branch: the **old** hook commits an unstaged manifest edit and leaves the tree clean; the **new** hook leaves that edit in the working tree and commits only what was staged. `--check` mode prints no paths
- [x] End-to-end release rehearsal: bumping only `package.json` and committing updates and stages all five manifests, changing zero non-version lines, and the result passes `validate:versions`
- [x] Stale lockfile still aborts the commit with no commit created
- [ ] Reviewer sanity-check: `/plugin install neon-postgres@neon` in Claude Code and `/add-plugin neon-postgres` in Cursor still work
