### PR TITLE
docs: guide agents to use direct connections for migrations, dumps, and replication

### DIFF
--- a/plugins/neon-postgres/skills/neon-postgres-branches/SKILL.md
+++ b/plugins/neon-postgres/skills/neon-postgres-branches/SKILL.md
@@ -89,6 +89,8 @@ Link: https://neon.com/docs/introduction/branching.md
    neon connection-string <branch-name>
    ```
 
+   When you run the migrations you're testing, use a **direct (non-pooled)** connection string, not a pooled one. Neon's pooled connections use PgBouncer in transaction mode, which doesn't support the session-level operations schema migration tools (Prisma Migrate, Drizzle Kit, Alembic, and others) rely on, so migrations over a pooled connection can fail. `neon connection-string` returns the direct string by default; make sure the hostname does not include the `-pooler` suffix. Use the pooled connection string only for your application's normal query traffic. See https://neon.com/docs/connect/connection-pooling.md.
+
 ## Create a Schema-Only Branch (Beta, Sensitive Data)
 
 Use this when users must not copy production rows into the test branch.
@@ -250,7 +252,7 @@ Because `neon checkout` applies this policy when it **creates** a branch, a fres
 Common CI/CD use cases for Neon branches:
 
 - **Per-PR preview deployments:** Branch on PR open, deploy the preview against it, delete on close. Each PR gets an isolated database branch. Injecting the branch's `DATABASE_URL` into the deployed app is hosting-provider-specific — see [preview-branches-with-cloudflare](https://github.com/neondatabase/preview-branches-with-cloudflare), [preview-branches-with-vercel](https://github.com/neondatabase/preview-branches-with-vercel), or [preview-branches-with-fly](https://github.com/neondatabase/preview-branches-with-fly) for tested patterns.
-- **Migration testing in CI:** Run risky schema changes against a branch with production-like data before merge.
+- **Migration testing in CI:** Run risky schema changes against a branch with production-like data before merge. Run the migrations over a direct (non-pooled) connection string (hostname without `-pooler`); pooled connections don't support the session-level operations migration tools require.
 - **Schema diff visibility:** Use the [schema-diff GitHub Action](https://github.com/marketplace/actions/neon-schema-diff-github-action) to auto-comment a DB-layer diff on the PR.
 
 ## Examples
@@ -267,6 +269,7 @@ Common CI/CD use cases for Neon branches:
 4. Provide commands:
    - `neon branches create --name migration-test --parent main --expires-at 2026-12-15T18:02:16Z`
    - `neon connection-string migration-test`
+5. Remind the user to run the migration over the direct (non-pooled) connection string (hostname without `-pooler`).
 
 ### Example 2: Sensitive data development workflow
 

--- a/plugins/neon-postgres/skills/neon/SKILL.md
+++ b/plugins/neon-postgres/skills/neon/SKILL.md
@@ -380,6 +380,15 @@ Apply for the Neon Agent Program for special program pricing here: https://neon.
 
 ## Gotchas
 
+### Pooled vs direct connections: use the direct URL for migrations, dumps, and replication
+
+Neon gives you two connection strings for the same database: a **pooled** one (hostname with the `-pooler` suffix, exposed as `DATABASE_URL`) and a **direct/unpooled** one (no `-pooler` suffix, exposed as `DATABASE_URL_UNPOOLED`). The pooled connection routes through PgBouncer in transaction mode, which doesn't support session-level operations. Choose the right one:
+
+- **Pooled (`DATABASE_URL`)** — your application's normal query traffic, especially serverless and connection-per-request workloads.
+- **Direct (`DATABASE_URL_UNPOOLED`)** — schema migrations (Prisma Migrate, Drizzle Kit, Alembic, and others), `pg_dump` / `pg_restore`, logical replication, `LISTEN`/`NOTIFY`, and anything relying on `SET` or other session state.
+
+Running migrations, dumps, or replication over the pooled connection can fail (for example with `prepared statement "s0" already exists`, `SET search_path` not persisting, or a write hitting a read-only transaction). See https://neon.com/docs/connect/connection-pooling.md.
+
 ### Neon Auth: "invalid domain"
 
 Neon Auth only redirects back to domains on its trusted-domains list. Anytime the domain your app runs on changes — a new production custom domain, a new deploy/preview URL, moving from `localhost` to a hosted environment, and so on — you must register the new domain with Neon Auth. Otherwise sign-in and OAuth callbacks fail with an **`invalid domain`** error because the redirect target isn't trusted.

--- a/skills/neon-postgres-branches/SKILL.md
+++ b/skills/neon-postgres-branches/SKILL.md
@@ -89,6 +89,8 @@ Link: https://neon.com/docs/introduction/branching.md
    neon connection-string <branch-name>
    ```
 
+   When you run the migrations you're testing, use a **direct (non-pooled)** connection string, not a pooled one. Neon's pooled connections use PgBouncer in transaction mode, which doesn't support the session-level operations schema migration tools (Prisma Migrate, Drizzle Kit, Alembic, and others) rely on, so migrations over a pooled connection can fail. `neon connection-string` returns the direct string by default; make sure the hostname does not include the `-pooler` suffix. Use the pooled connection string only for your application's normal query traffic. See https://neon.com/docs/connect/connection-pooling.md.
+
 ## Create a Schema-Only Branch (Beta, Sensitive Data)
 
 Use this when users must not copy production rows into the test branch.
@@ -250,7 +252,7 @@ Because `neon checkout` applies this policy when it **creates** a branch, a fres
 Common CI/CD use cases for Neon branches:
 
 - **Per-PR preview deployments:** Branch on PR open, deploy the preview against it, delete on close. Each PR gets an isolated database branch. Injecting the branch's `DATABASE_URL` into the deployed app is hosting-provider-specific — see [preview-branches-with-cloudflare](https://github.com/neondatabase/preview-branches-with-cloudflare), [preview-branches-with-vercel](https://github.com/neondatabase/preview-branches-with-vercel), or [preview-branches-with-fly](https://github.com/neondatabase/preview-branches-with-fly) for tested patterns.
-- **Migration testing in CI:** Run risky schema changes against a branch with production-like data before merge.
+- **Migration testing in CI:** Run risky schema changes against a branch with production-like data before merge. Run the migrations over a direct (non-pooled) connection string (hostname without `-pooler`); pooled connections don't support the session-level operations migration tools require.
 - **Schema diff visibility:** Use the [schema-diff GitHub Action](https://github.com/marketplace/actions/neon-schema-diff-github-action) to auto-comment a DB-layer diff on the PR.
 
 ## Examples
@@ -267,6 +269,7 @@ Common CI/CD use cases for Neon branches:
 4. Provide commands:
    - `neon branches create --name migration-test --parent main --expires-at 2026-12-15T18:02:16Z`
    - `neon connection-string migration-test`
+5. Remind the user to run the migration over the direct (non-pooled) connection string (hostname without `-pooler`).
 
 ### Example 2: Sensitive data development workflow
 

--- a/skills/neon/SKILL.md
+++ b/skills/neon/SKILL.md
@@ -380,6 +380,15 @@ Apply for the Neon Agent Program for special program pricing here: https://neon.
 
 ## Gotchas
 
+### Pooled vs direct connections: use the direct URL for migrations, dumps, and replication
+
+Neon gives you two connection strings for the same database: a **pooled** one (hostname with the `-pooler` suffix, exposed as `DATABASE_URL`) and a **direct/unpooled** one (no `-pooler` suffix, exposed as `DATABASE_URL_UNPOOLED`). The pooled connection routes through PgBouncer in transaction mode, which doesn't support session-level operations. Choose the right one:
+
+- **Pooled (`DATABASE_URL`)** — your application's normal query traffic, especially serverless and connection-per-request workloads.
+- **Direct (`DATABASE_URL_UNPOOLED`)** — schema migrations (Prisma Migrate, Drizzle Kit, Alembic, and others), `pg_dump` / `pg_restore`, logical replication, `LISTEN`/`NOTIFY`, and anything relying on `SET` or other session state.
+
+Running migrations, dumps, or replication over the pooled connection can fail (for example with `prepared statement "s0" already exists`, `SET search_path` not persisting, or a write hitting a read-only transaction). See https://neon.com/docs/connect/connection-pooling.md.
+
 ### Neon Auth: "invalid domain"
 
 Neon Auth only redirects back to domains on its trusted-domains list. Anytime the domain your app runs on changes — a new production custom domain, a new deploy/preview URL, moving from `localhost` to a hosted environment, and so on — you must register the new domain with Neon Auth. Otherwise sign-in and OAuth callbacks fail with an **`invalid domain`** error because the redirect target isn't trusted.


### PR DESCRIPTION
## Why

This guidance is being added to address **support issues where users and agents are using pooled connection strings in places they should not** — specifically for schema migrations, `pg_dump`/`pg_restore`, and logical replication.

Support is seeing cases where users (and agents) run these workflows over a **pooled** connection string, hitting errors including `cannot execute ... in a read-only transaction (SQLSTATE 25006)`, `prepared statement "s0" already exists`, and `SET search_path` not persisting. Neon's pooled endpoint uses PgBouncer in transaction mode, which doesn't support the session-level operations these tools rely on.

The `neon-postgres` skill already has a "When to use pooled vs direct connections" table, but two skills that lead agents straight into these workflows did not mention it.

## Changes

- **`neon`** — new **Gotchas** entry: "Pooled vs direct connections: use the direct URL for migrations, dumps, and replication." Explains `DATABASE_URL` (pooled) vs `DATABASE_URL_UNPOOLED` (direct) and lists exactly which operations need the direct URL.
- **`neon-postgres-branches`** — this skill is all about migration testing on branches but never flagged the connection type. Added a note at the connection-string step, in the CI migration-testing pattern, and in the migration-testing example, that migrations must run over a direct (non-pooled) connection.

Plugin skill copies under `plugins/neon-postgres/skills/` were re-synced via `scripts/sync-plugin-skills.mjs`. `validate:skills`, `validate:references`, and `validate:plugin-skills` all pass.

## Related

- The corresponding Neon docs changes are in neondatabase/website#5482.
- Note: the `neon-postgres-agent-platforms` skill (which returns a pooled connection string from `create-project.ts`) lives in the separate `neondatabase/neon-for-agent-platforms` repo and will need a follow-up there.

This pull request and its description were written by Isaac.