### PR TITLE
Add migration guidance and a pooled-connection gotcha to the neon-postgres skill

### DIFF
--- a/plugins/neon-postgres/skills/neon-postgres/SKILL.md
+++ b/plugins/neon-postgres/skills/neon-postgres/SKILL.md
@@ -166,6 +166,15 @@ Link: https://neon.com/docs/guides/logical-replication-guide.md
 
 ## Gotchas
 
+### A migration, dump, or replication slot fails over a pooled connection
+
+Schema migration tools — Prisma Migrate, Drizzle Kit, Knex, TypeORM, Flyway, Liquibase, Aerich — plus `pg_dump` / `pg_restore` and logical replication need the direct connection string. Over a pooled one they fail in ways that don't name pooling as the cause:
+
+- `prepared statement "s0" already exists` — Prisma Migrate over the pooled endpoint.
+- `cannot execute ALTER TABLE in a read-only transaction (SQLSTATE 25006)` — a pooled backend that inherited `default_transaction_read_only` from an earlier client. It's intermittent, so it reads as a flake rather than a connection-type problem.
+
+Point the tool's migration URL at the direct string and leave the application on the pooled one. Most tools take both — Prisma's `directUrl` alongside `url`, for example.
+
 ### Pooled connections don't preserve session state
 
 The pooled endpoint (`-pooler` in the hostname) is PgBouncer in transaction mode: the backend connection returns to the pool after every transaction, so session state is not preserved for a client across transactions and can leak to another client. The resulting failure never mentions pooling — a `SET search_path` applies inside its own transaction, then a later query fails with `relation "mytable" does not exist`. Use the direct connection string for everything in the Direct rows of [When to use pooled vs direct connections](#when-to-use-pooled-vs-direct-connections).

--- a/plugins/neon-postgres/skills/neon-postgres/SKILL.md
+++ b/plugins/neon-postgres/skills/neon-postgres/SKILL.md
@@ -3,13 +3,14 @@ name: neon-postgres
 description: >-
   Guides and best practices for working with Lakebase Postgres, the database
   behind Neon. Covers setup, connection methods and drivers, pooled vs direct
-  connections, branching, autoscaling, scale-to-zero, instant restore, read
-  replicas, connection pooling, IP allow lists, and logical replication.
+  connections, branching, schema migrations, autoscaling, scale-to-zero, instant
+  restore, read replicas, connection pooling, IP allow lists, and logical
+  replication.
   Use when users ask about "Lakebase Postgres", "Neon setup", "connect to Neon",
   "Neon project", "DATABASE_URL", "serverless Postgres", "Neon CLI", "neon", "Neon MCP",
   "Neon Auth", "@neondatabase/serverless", "@neondatabase/neon-js",
-  "scale to zero", "Neon autoscaling", "Neon read replica", or
-  "Neon connection pooling".
+  "scale to zero", "Neon autoscaling", "Neon read replica",
+  "Neon connection pooling", or "Neon schema migrations".
 metadata:
   parent: neon
 ---
@@ -90,7 +91,7 @@ npx skills add neondatabase/agent-skills --skill neon-postgres-branches
 
 Test a migration on a branch before applying it to production: branch production, run the migration there against production-like data, then apply it to production. Use the `neon-postgres-branches` skill for the branch workflow.
 
-Run migrations over the direct connection string — `DATABASE_URL_UNPOOLED`, the hostname without `-pooler`. Migration tools depend on session state that the pooled endpoint does not keep.
+Run migrations over the direct connection string — the hostname without `-pooler`, written as `DATABASE_URL_UNPOOLED` by `neon env pull`. Migration tools rely on session-level operations the pooled endpoint does not support.
 
 ## Autoscaling
 
@@ -165,8 +166,8 @@ Link: https://neon.com/docs/guides/logical-replication-guide.md
 
 ## Gotchas
 
-### Pooled connections drop session state
+### Pooled connections don't preserve session state
 
-The pooled endpoint (`-pooler` in the hostname, `DATABASE_URL`) runs through PgBouncer in transaction mode, so nothing a statement sets survives into the next one. Everything in the Direct rows of [When to use pooled vs direct connections](#when-to-use-pooled-vs-direct-connections) needs the direct string, `DATABASE_URL_UNPOOLED`. Over a pooled connection those workloads fail without naming pooling as the cause — a migration tool reports `prepared statement "s0" already exists`, or a `SET search_path` silently doesn't apply.
+The pooled endpoint (`-pooler` in the hostname) is PgBouncer in transaction mode: the backend connection returns to the pool after every transaction, so session state doesn't survive into the next transaction and can leak to another client. The resulting failure never mentions pooling — a `SET search_path` applies inside its own transaction, then a later query fails with `relation "mytable" does not exist`. Use the direct connection string for everything in the Direct rows of [When to use pooled vs direct connections](#when-to-use-pooled-vs-direct-connections).
 
 Link: https://neon.com/docs/connect/connection-pooling.md

--- a/plugins/neon-postgres/skills/neon-postgres/SKILL.md
+++ b/plugins/neon-postgres/skills/neon-postgres/SKILL.md
@@ -91,7 +91,7 @@ npx skills add neondatabase/agent-skills --skill neon-postgres-branches
 
 Test a migration on a branch of production, against production-like data, before applying it to production.
 
-Run migrations over the direct connection string — the hostname without `-pooler`, written as `DATABASE_URL_UNPOOLED` by `neon env pull`. Migration tools rely on session-level operations the pooled endpoint does not support.
+Use a **direct (non-pooled)** connection string when you run the migration, not a pooled one. Neon's pooled connections use PgBouncer in transaction mode, which doesn't support the session-level operations schema migration tools (Prisma Migrate, Drizzle Kit, Alembic, and others) rely on, so migrations over a pooled connection can fail. `neon connection-string` returns the direct string by default; make sure the hostname does not include the `-pooler` suffix. Use the pooled connection string only for your application's normal query traffic.
 
 ## Autoscaling
 
@@ -166,17 +166,11 @@ Link: https://neon.com/docs/guides/logical-replication-guide.md
 
 ## Gotchas
 
-### A migration, dump, or replication slot fails over a pooled connection
+### Pooled vs direct connections: use the direct URL for migrations, dumps, and replication
 
-Schema migration tools — Prisma Migrate, Drizzle Kit, Knex, TypeORM, Flyway, Liquibase, Aerich — plus `pg_dump` / `pg_restore` and logical replication need the direct connection string. Over a pooled one they fail in ways that don't name pooling as the cause:
+Neon gives you two connection strings for the same database: a **pooled** one (hostname with the `-pooler` suffix) and a **direct/unpooled** one (no `-pooler` suffix). `neon env pull` writes them as `DATABASE_URL` and `DATABASE_URL_UNPOOLED`. The pooled connection routes through PgBouncer in transaction mode, which doesn't support session-level operations. Choose the right one:
 
-- `prepared statement "s0" already exists` — Prisma Migrate over the pooled endpoint.
-- `cannot execute ALTER TABLE in a read-only transaction (SQLSTATE 25006)` — a pooled backend that inherited `default_transaction_read_only` from an earlier client. It's intermittent, so it reads as a flake rather than a connection-type problem.
+- **Pooled (`DATABASE_URL`)** — your application's normal query traffic, especially serverless and connection-per-request workloads.
+- **Direct (`DATABASE_URL_UNPOOLED`)** — schema migrations (Prisma Migrate, Drizzle Kit, Alembic, and others), `pg_dump` / `pg_restore`, logical replication, `LISTEN`/`NOTIFY`, and anything relying on `SET` or other session state.
 
-Point the tool's migration URL at the direct string and leave the application on the pooled one. Most tools take both — Prisma's `directUrl` alongside `url`, for example.
-
-### Pooled connections don't preserve session state — `relation "mytable" does not exist`
-
-The pooled endpoint (`-pooler` in the hostname) is PgBouncer in transaction mode: the backend connection returns to the pool after every transaction, so session state is not preserved for a client across transactions and can leak to another client. The resulting failure never mentions pooling — a `SET search_path` applies inside its own transaction, then a later query fails with `relation "mytable" does not exist`. Use the direct connection string for everything in the Direct rows of [When to use pooled vs direct connections](#when-to-use-pooled-vs-direct-connections).
-
-Link: https://neon.com/docs/connect/connection-pooling.md
+Running migrations, dumps, or replication over the pooled connection can fail, and never in a way that names pooling: `prepared statement "s0" already exists` from Prisma Migrate, a `SET search_path` that doesn't persist past its own transaction so the next query reports `relation "mytable" does not exist`, or a write hitting a read-only transaction that a pooled backend inherited from an earlier client. See https://neon.com/docs/connect/connection-pooling.md.

--- a/plugins/neon-postgres/skills/neon-postgres/SKILL.md
+++ b/plugins/neon-postgres/skills/neon-postgres/SKILL.md
@@ -91,7 +91,7 @@ npx skills add neondatabase/agent-skills --skill neon-postgres-branches
 
 Test a migration on a branch of production, against production-like data, before applying it to production.
 
-Use a **direct (non-pooled)** connection string when you run the migration, not a pooled one. Neon's pooled connections use PgBouncer in transaction mode, which doesn't support the session-level operations schema migration tools (Prisma Migrate, Drizzle Kit, Alembic, and others) rely on, so migrations over a pooled connection can fail. `neon connection-string` returns the direct string by default; make sure the hostname does not include the `-pooler` suffix. Use the pooled connection string only for your application's normal query traffic.
+Use a **direct (non-pooled)** connection string when you run the migration, not a pooled one. `neon connection-string` returns the direct string by default; make sure the hostname does not include the `-pooler` suffix.
 
 ## Autoscaling
 
@@ -173,4 +173,4 @@ Neon gives you two connection strings for the same database: a **pooled** one (h
 - **Pooled (`DATABASE_URL`)** — your application's normal query traffic, especially serverless and connection-per-request workloads.
 - **Direct (`DATABASE_URL_UNPOOLED`)** — schema migrations (Prisma Migrate, Drizzle Kit, Alembic, and others), `pg_dump` / `pg_restore`, logical replication, `LISTEN`/`NOTIFY`, and anything relying on `SET` or other session state.
 
-Running migrations, dumps, or replication over the pooled connection can fail, and never in a way that names pooling: `prepared statement "s0" already exists` from Prisma Migrate, a `SET search_path` that doesn't persist past its own transaction so the next query reports `relation "mytable" does not exist`, or a write hitting a read-only transaction that a pooled backend inherited from an earlier client. See https://neon.com/docs/connect/connection-pooling.md.
+Running migrations, dumps, or replication over the pooled connection can fail, and never in a way that names pooling: `prepared statement "s0" already exists` from Prisma Migrate, a `SET search_path` that doesn't persist past its own transaction so the next query reports `relation "mytable" does not exist`, or a write intermittently hitting a read-only transaction (`SQLSTATE 25006`) that a pooled backend inherited from an earlier client. Migration tools generally take both strings at once — Prisma's `directUrl` alongside `url` — so point that at the direct one rather than swapping `DATABASE_URL` and losing pooling for the application. See https://neon.com/docs/connect/connection-pooling.md.

--- a/plugins/neon-postgres/skills/neon-postgres/SKILL.md
+++ b/plugins/neon-postgres/skills/neon-postgres/SKILL.md
@@ -168,6 +168,6 @@ Link: https://neon.com/docs/guides/logical-replication-guide.md
 
 ### Pooled connections don't preserve session state
 
-The pooled endpoint (`-pooler` in the hostname) is PgBouncer in transaction mode: the backend connection returns to the pool after every transaction, so session state doesn't survive into the next transaction and can leak to another client. The resulting failure never mentions pooling — a `SET search_path` applies inside its own transaction, then a later query fails with `relation "mytable" does not exist`. Use the direct connection string for everything in the Direct rows of [When to use pooled vs direct connections](#when-to-use-pooled-vs-direct-connections).
+The pooled endpoint (`-pooler` in the hostname) is PgBouncer in transaction mode: the backend connection returns to the pool after every transaction, so session state is not preserved for a client across transactions and can leak to another client. The resulting failure never mentions pooling — a `SET search_path` applies inside its own transaction, then a later query fails with `relation "mytable" does not exist`. Use the direct connection string for everything in the Direct rows of [When to use pooled vs direct connections](#when-to-use-pooled-vs-direct-connections).
 
 Link: https://neon.com/docs/connect/connection-pooling.md

--- a/plugins/neon-postgres/skills/neon-postgres/SKILL.md
+++ b/plugins/neon-postgres/skills/neon-postgres/SKILL.md
@@ -10,7 +10,7 @@ description: >-
   "Neon project", "DATABASE_URL", "serverless Postgres", "Neon CLI", "neon", "Neon MCP",
   "Neon Auth", "@neondatabase/serverless", "@neondatabase/neon-js",
   "scale to zero", "Neon autoscaling", "Neon read replica",
-  "Neon connection pooling", or "Neon schema migrations".
+  "Neon connection pooling", or "schema migrations".
 metadata:
   parent: neon
 ---
@@ -89,7 +89,7 @@ npx skills add neondatabase/agent-skills --skill neon-postgres-branches
 
 ## Migrations
 
-Test a migration on a branch before applying it to production: branch production, run the migration there against production-like data, then apply it to production. Use the `neon-postgres-branches` skill for the branch workflow.
+Test a migration on a branch of production, against production-like data, before applying it to production.
 
 Run migrations over the direct connection string — the hostname without `-pooler`, written as `DATABASE_URL_UNPOOLED` by `neon env pull`. Migration tools rely on session-level operations the pooled endpoint does not support.
 
@@ -175,7 +175,7 @@ Schema migration tools — Prisma Migrate, Drizzle Kit, Knex, TypeORM, Flyway, L
 
 Point the tool's migration URL at the direct string and leave the application on the pooled one. Most tools take both — Prisma's `directUrl` alongside `url`, for example.
 
-### Pooled connections don't preserve session state
+### Pooled connections don't preserve session state — `relation "mytable" does not exist`
 
 The pooled endpoint (`-pooler` in the hostname) is PgBouncer in transaction mode: the backend connection returns to the pool after every transaction, so session state is not preserved for a client across transactions and can leak to another client. The resulting failure never mentions pooling — a `SET search_path` applies inside its own transaction, then a later query fails with `relation "mytable" does not exist`. Use the direct connection string for everything in the Direct rows of [When to use pooled vs direct connections](#when-to-use-pooled-vs-direct-connections).
 

--- a/plugins/neon-postgres/skills/neon-postgres/SKILL.md
+++ b/plugins/neon-postgres/skills/neon-postgres/SKILL.md
@@ -86,6 +86,12 @@ For detailed branch creation workflows (normal vs schema-only branches, reset-fr
 npx skills add neondatabase/agent-skills --skill neon-postgres-branches
 ```
 
+## Migrations
+
+Test a migration on a branch before applying it to production: branch production, run the migration there against production-like data, then apply it to production. Use the `neon-postgres-branches` skill for the branch workflow.
+
+Run migrations over the direct connection string — `DATABASE_URL_UNPOOLED`, the hostname without `-pooler`. Migration tools depend on session state that the pooled endpoint does not keep.
+
 ## Autoscaling
 
 Use this when the user needs compute to scale automatically with workload and wants guidance on CU sizing and runtime behavior.
@@ -156,3 +162,11 @@ Key points:
 - Useful for replicating to/from external Postgres systems.
 
 Link: https://neon.com/docs/guides/logical-replication-guide.md
+
+## Gotchas
+
+### Pooled connections drop session state
+
+The pooled endpoint (`-pooler` in the hostname, `DATABASE_URL`) runs through PgBouncer in transaction mode, so nothing a statement sets survives into the next one. Everything in the Direct rows of [When to use pooled vs direct connections](#when-to-use-pooled-vs-direct-connections) needs the direct string, `DATABASE_URL_UNPOOLED`. Over a pooled connection those workloads fail without naming pooling as the cause — a migration tool reports `prepared statement "s0" already exists`, or a `SET search_path` silently doesn't apply.
+
+Link: https://neon.com/docs/connect/connection-pooling.md

--- a/skills/neon-postgres/SKILL.md
+++ b/skills/neon-postgres/SKILL.md
@@ -166,6 +166,15 @@ Link: https://neon.com/docs/guides/logical-replication-guide.md
 
 ## Gotchas
 
+### A migration, dump, or replication slot fails over a pooled connection
+
+Schema migration tools — Prisma Migrate, Drizzle Kit, Knex, TypeORM, Flyway, Liquibase, Aerich — plus `pg_dump` / `pg_restore` and logical replication need the direct connection string. Over a pooled one they fail in ways that don't name pooling as the cause:
+
+- `prepared statement "s0" already exists` — Prisma Migrate over the pooled endpoint.
+- `cannot execute ALTER TABLE in a read-only transaction (SQLSTATE 25006)` — a pooled backend that inherited `default_transaction_read_only` from an earlier client. It's intermittent, so it reads as a flake rather than a connection-type problem.
+
+Point the tool's migration URL at the direct string and leave the application on the pooled one. Most tools take both — Prisma's `directUrl` alongside `url`, for example.
+
 ### Pooled connections don't preserve session state
 
 The pooled endpoint (`-pooler` in the hostname) is PgBouncer in transaction mode: the backend connection returns to the pool after every transaction, so session state is not preserved for a client across transactions and can leak to another client. The resulting failure never mentions pooling — a `SET search_path` applies inside its own transaction, then a later query fails with `relation "mytable" does not exist`. Use the direct connection string for everything in the Direct rows of [When to use pooled vs direct connections](#when-to-use-pooled-vs-direct-connections).

--- a/skills/neon-postgres/SKILL.md
+++ b/skills/neon-postgres/SKILL.md
@@ -3,13 +3,14 @@ name: neon-postgres
 description: >-
   Guides and best practices for working with Lakebase Postgres, the database
   behind Neon. Covers setup, connection methods and drivers, pooled vs direct
-  connections, branching, autoscaling, scale-to-zero, instant restore, read
-  replicas, connection pooling, IP allow lists, and logical replication.
+  connections, branching, schema migrations, autoscaling, scale-to-zero, instant
+  restore, read replicas, connection pooling, IP allow lists, and logical
+  replication.
   Use when users ask about "Lakebase Postgres", "Neon setup", "connect to Neon",
   "Neon project", "DATABASE_URL", "serverless Postgres", "Neon CLI", "neon", "Neon MCP",
   "Neon Auth", "@neondatabase/serverless", "@neondatabase/neon-js",
-  "scale to zero", "Neon autoscaling", "Neon read replica", or
-  "Neon connection pooling".
+  "scale to zero", "Neon autoscaling", "Neon read replica",
+  "Neon connection pooling", or "Neon schema migrations".
 metadata:
   parent: neon
 ---
@@ -90,7 +91,7 @@ npx skills add neondatabase/agent-skills --skill neon-postgres-branches
 
 Test a migration on a branch before applying it to production: branch production, run the migration there against production-like data, then apply it to production. Use the `neon-postgres-branches` skill for the branch workflow.
 
-Run migrations over the direct connection string — `DATABASE_URL_UNPOOLED`, the hostname without `-pooler`. Migration tools depend on session state that the pooled endpoint does not keep.
+Run migrations over the direct connection string — the hostname without `-pooler`, written as `DATABASE_URL_UNPOOLED` by `neon env pull`. Migration tools rely on session-level operations the pooled endpoint does not support.
 
 ## Autoscaling
 
@@ -165,8 +166,8 @@ Link: https://neon.com/docs/guides/logical-replication-guide.md
 
 ## Gotchas
 
-### Pooled connections drop session state
+### Pooled connections don't preserve session state
 
-The pooled endpoint (`-pooler` in the hostname, `DATABASE_URL`) runs through PgBouncer in transaction mode, so nothing a statement sets survives into the next one. Everything in the Direct rows of [When to use pooled vs direct connections](#when-to-use-pooled-vs-direct-connections) needs the direct string, `DATABASE_URL_UNPOOLED`. Over a pooled connection those workloads fail without naming pooling as the cause — a migration tool reports `prepared statement "s0" already exists`, or a `SET search_path` silently doesn't apply.
+The pooled endpoint (`-pooler` in the hostname) is PgBouncer in transaction mode: the backend connection returns to the pool after every transaction, so session state doesn't survive into the next transaction and can leak to another client. The resulting failure never mentions pooling — a `SET search_path` applies inside its own transaction, then a later query fails with `relation "mytable" does not exist`. Use the direct connection string for everything in the Direct rows of [When to use pooled vs direct connections](#when-to-use-pooled-vs-direct-connections).
 
 Link: https://neon.com/docs/connect/connection-pooling.md

--- a/skills/neon-postgres/SKILL.md
+++ b/skills/neon-postgres/SKILL.md
@@ -91,7 +91,7 @@ npx skills add neondatabase/agent-skills --skill neon-postgres-branches
 
 Test a migration on a branch of production, against production-like data, before applying it to production.
 
-Run migrations over the direct connection string — the hostname without `-pooler`, written as `DATABASE_URL_UNPOOLED` by `neon env pull`. Migration tools rely on session-level operations the pooled endpoint does not support.
+Use a **direct (non-pooled)** connection string when you run the migration, not a pooled one. Neon's pooled connections use PgBouncer in transaction mode, which doesn't support the session-level operations schema migration tools (Prisma Migrate, Drizzle Kit, Alembic, and others) rely on, so migrations over a pooled connection can fail. `neon connection-string` returns the direct string by default; make sure the hostname does not include the `-pooler` suffix. Use the pooled connection string only for your application's normal query traffic.
 
 ## Autoscaling
 
@@ -166,17 +166,11 @@ Link: https://neon.com/docs/guides/logical-replication-guide.md
 
 ## Gotchas
 
-### A migration, dump, or replication slot fails over a pooled connection
+### Pooled vs direct connections: use the direct URL for migrations, dumps, and replication
 
-Schema migration tools — Prisma Migrate, Drizzle Kit, Knex, TypeORM, Flyway, Liquibase, Aerich — plus `pg_dump` / `pg_restore` and logical replication need the direct connection string. Over a pooled one they fail in ways that don't name pooling as the cause:
+Neon gives you two connection strings for the same database: a **pooled** one (hostname with the `-pooler` suffix) and a **direct/unpooled** one (no `-pooler` suffix). `neon env pull` writes them as `DATABASE_URL` and `DATABASE_URL_UNPOOLED`. The pooled connection routes through PgBouncer in transaction mode, which doesn't support session-level operations. Choose the right one:
 
-- `prepared statement "s0" already exists` — Prisma Migrate over the pooled endpoint.
-- `cannot execute ALTER TABLE in a read-only transaction (SQLSTATE 25006)` — a pooled backend that inherited `default_transaction_read_only` from an earlier client. It's intermittent, so it reads as a flake rather than a connection-type problem.
+- **Pooled (`DATABASE_URL`)** — your application's normal query traffic, especially serverless and connection-per-request workloads.
+- **Direct (`DATABASE_URL_UNPOOLED`)** — schema migrations (Prisma Migrate, Drizzle Kit, Alembic, and others), `pg_dump` / `pg_restore`, logical replication, `LISTEN`/`NOTIFY`, and anything relying on `SET` or other session state.
 
-Point the tool's migration URL at the direct string and leave the application on the pooled one. Most tools take both — Prisma's `directUrl` alongside `url`, for example.
-
-### Pooled connections don't preserve session state — `relation "mytable" does not exist`
-
-The pooled endpoint (`-pooler` in the hostname) is PgBouncer in transaction mode: the backend connection returns to the pool after every transaction, so session state is not preserved for a client across transactions and can leak to another client. The resulting failure never mentions pooling — a `SET search_path` applies inside its own transaction, then a later query fails with `relation "mytable" does not exist`. Use the direct connection string for everything in the Direct rows of [When to use pooled vs direct connections](#when-to-use-pooled-vs-direct-connections).
-
-Link: https://neon.com/docs/connect/connection-pooling.md
+Running migrations, dumps, or replication over the pooled connection can fail, and never in a way that names pooling: `prepared statement "s0" already exists` from Prisma Migrate, a `SET search_path` that doesn't persist past its own transaction so the next query reports `relation "mytable" does not exist`, or a write hitting a read-only transaction that a pooled backend inherited from an earlier client. See https://neon.com/docs/connect/connection-pooling.md.

--- a/skills/neon-postgres/SKILL.md
+++ b/skills/neon-postgres/SKILL.md
@@ -91,7 +91,7 @@ npx skills add neondatabase/agent-skills --skill neon-postgres-branches
 
 Test a migration on a branch of production, against production-like data, before applying it to production.
 
-Use a **direct (non-pooled)** connection string when you run the migration, not a pooled one. Neon's pooled connections use PgBouncer in transaction mode, which doesn't support the session-level operations schema migration tools (Prisma Migrate, Drizzle Kit, Alembic, and others) rely on, so migrations over a pooled connection can fail. `neon connection-string` returns the direct string by default; make sure the hostname does not include the `-pooler` suffix. Use the pooled connection string only for your application's normal query traffic.
+Use a **direct (non-pooled)** connection string when you run the migration, not a pooled one. `neon connection-string` returns the direct string by default; make sure the hostname does not include the `-pooler` suffix.
 
 ## Autoscaling
 
@@ -173,4 +173,4 @@ Neon gives you two connection strings for the same database: a **pooled** one (h
 - **Pooled (`DATABASE_URL`)** — your application's normal query traffic, especially serverless and connection-per-request workloads.
 - **Direct (`DATABASE_URL_UNPOOLED`)** — schema migrations (Prisma Migrate, Drizzle Kit, Alembic, and others), `pg_dump` / `pg_restore`, logical replication, `LISTEN`/`NOTIFY`, and anything relying on `SET` or other session state.
 
-Running migrations, dumps, or replication over the pooled connection can fail, and never in a way that names pooling: `prepared statement "s0" already exists` from Prisma Migrate, a `SET search_path` that doesn't persist past its own transaction so the next query reports `relation "mytable" does not exist`, or a write hitting a read-only transaction that a pooled backend inherited from an earlier client. See https://neon.com/docs/connect/connection-pooling.md.
+Running migrations, dumps, or replication over the pooled connection can fail, and never in a way that names pooling: `prepared statement "s0" already exists` from Prisma Migrate, a `SET search_path` that doesn't persist past its own transaction so the next query reports `relation "mytable" does not exist`, or a write intermittently hitting a read-only transaction (`SQLSTATE 25006`) that a pooled backend inherited from an earlier client. Migration tools generally take both strings at once — Prisma's `directUrl` alongside `url` — so point that at the direct one rather than swapping `DATABASE_URL` and losing pooling for the application. See https://neon.com/docs/connect/connection-pooling.md.

--- a/skills/neon-postgres/SKILL.md
+++ b/skills/neon-postgres/SKILL.md
@@ -168,6 +168,6 @@ Link: https://neon.com/docs/guides/logical-replication-guide.md
 
 ### Pooled connections don't preserve session state
 
-The pooled endpoint (`-pooler` in the hostname) is PgBouncer in transaction mode: the backend connection returns to the pool after every transaction, so session state doesn't survive into the next transaction and can leak to another client. The resulting failure never mentions pooling — a `SET search_path` applies inside its own transaction, then a later query fails with `relation "mytable" does not exist`. Use the direct connection string for everything in the Direct rows of [When to use pooled vs direct connections](#when-to-use-pooled-vs-direct-connections).
+The pooled endpoint (`-pooler` in the hostname) is PgBouncer in transaction mode: the backend connection returns to the pool after every transaction, so session state is not preserved for a client across transactions and can leak to another client. The resulting failure never mentions pooling — a `SET search_path` applies inside its own transaction, then a later query fails with `relation "mytable" does not exist`. Use the direct connection string for everything in the Direct rows of [When to use pooled vs direct connections](#when-to-use-pooled-vs-direct-connections).
 
 Link: https://neon.com/docs/connect/connection-pooling.md

--- a/skills/neon-postgres/SKILL.md
+++ b/skills/neon-postgres/SKILL.md
@@ -10,7 +10,7 @@ description: >-
   "Neon project", "DATABASE_URL", "serverless Postgres", "Neon CLI", "neon", "Neon MCP",
   "Neon Auth", "@neondatabase/serverless", "@neondatabase/neon-js",
   "scale to zero", "Neon autoscaling", "Neon read replica",
-  "Neon connection pooling", or "Neon schema migrations".
+  "Neon connection pooling", or "schema migrations".
 metadata:
   parent: neon
 ---
@@ -89,7 +89,7 @@ npx skills add neondatabase/agent-skills --skill neon-postgres-branches
 
 ## Migrations
 
-Test a migration on a branch before applying it to production: branch production, run the migration there against production-like data, then apply it to production. Use the `neon-postgres-branches` skill for the branch workflow.
+Test a migration on a branch of production, against production-like data, before applying it to production.
 
 Run migrations over the direct connection string — the hostname without `-pooler`, written as `DATABASE_URL_UNPOOLED` by `neon env pull`. Migration tools rely on session-level operations the pooled endpoint does not support.
 
@@ -175,7 +175,7 @@ Schema migration tools — Prisma Migrate, Drizzle Kit, Knex, TypeORM, Flyway, L
 
 Point the tool's migration URL at the direct string and leave the application on the pooled one. Most tools take both — Prisma's `directUrl` alongside `url`, for example.
 
-### Pooled connections don't preserve session state
+### Pooled connections don't preserve session state — `relation "mytable" does not exist`
 
 The pooled endpoint (`-pooler` in the hostname) is PgBouncer in transaction mode: the backend connection returns to the pool after every transaction, so session state is not preserved for a client across transactions and can leak to another client. The resulting failure never mentions pooling — a `SET search_path` applies inside its own transaction, then a later query fails with `relation "mytable" does not exist`. Use the direct connection string for everything in the Direct rows of [When to use pooled vs direct connections](#when-to-use-pooled-vs-direct-connections).
 

--- a/skills/neon-postgres/SKILL.md
+++ b/skills/neon-postgres/SKILL.md
@@ -86,6 +86,12 @@ For detailed branch creation workflows (normal vs schema-only branches, reset-fr
 npx skills add neondatabase/agent-skills --skill neon-postgres-branches
 ```
 
+## Migrations
+
+Test a migration on a branch before applying it to production: branch production, run the migration there against production-like data, then apply it to production. Use the `neon-postgres-branches` skill for the branch workflow.
+
+Run migrations over the direct connection string — `DATABASE_URL_UNPOOLED`, the hostname without `-pooler`. Migration tools depend on session state that the pooled endpoint does not keep.
+
 ## Autoscaling
 
 Use this when the user needs compute to scale automatically with workload and wants guidance on CU sizing and runtime behavior.
@@ -156,3 +162,11 @@ Key points:
 - Useful for replicating to/from external Postgres systems.
 
 Link: https://neon.com/docs/guides/logical-replication-guide.md
+
+## Gotchas
+
+### Pooled connections drop session state
+
+The pooled endpoint (`-pooler` in the hostname, `DATABASE_URL`) runs through PgBouncer in transaction mode, so nothing a statement sets survives into the next one. Everything in the Direct rows of [When to use pooled vs direct connections](#when-to-use-pooled-vs-direct-connections) needs the direct string, `DATABASE_URL_UNPOOLED`. Over a pooled connection those workloads fail without naming pooling as the cause — a migration tool reports `prepared statement "s0" already exists`, or a `SET search_path` silently doesn't apply.
+
+Link: https://neon.com/docs/connect/connection-pooling.md


### PR DESCRIPTION
Replaces #82, which put the same guidance in the `neon` and `neon-postgres-branches` skills. The content and the wording are right; the placement isn't. `neon-postgres` is the skill about Lakebase Postgres and connections, and it already owns the pooled-vs-direct decision.

## Problem

Support sees users and agents run schema migrations, `pg_dump`/`pg_restore`, and logical replication over the **pooled** connection string. Neon's pooled endpoint is PgBouncer in transaction mode: the backend connection returns to the pool after every transaction, so session state is not preserved for a client across transactions and can leak to another client. The failure never names pooling as the cause — from Neon's own [pooling docs](https://neon.com/docs/connect/connection-pooling):

```sql
SET search_path TO myschema;
SELECT * FROM mytable;  -- works in this transaction
-- transaction ends, connection returns to the pool
SELECT * FROM mytable;  -- ERROR: relation "mytable" does not exist
```

The matching docs change, neondatabase/website#5482, is merged across the Drizzle, Knex, TypeORM, Flyway, Liquibase, Tortoise, `pg_dump`, and logical-replication guides.

`skills/neon-postgres/SKILL.md` already carried a "When to use pooled vs direct connections" table naming the Direct use cases. What it did not carry: why those rows are Direct, what the failure looks like, or the instruction to test a migration on a branch before applying it to production — even though `neon-postgres-branches` recommends exactly that workflow.

## Changes

Two sections added to `skills/neon-postgres/SKILL.md`, plus two frontmatter lines. `+28 / -4` in the source file; the 4 removed lines are reflowed frontmatter, not deleted content.

`## Migrations`, after `## Branching` so the branch concept is already introduced:

> Test a migration on a branch of production, against production-like data, before applying it to production.
>
> Use a **direct (non-pooled)** connection string when you run the migration, not a pooled one. `neon connection-string` returns the direct string by default; make sure the hostname does not include the `-pooler` suffix.

The reason and the tool list live in the Gotchas entry rather than being paraphrased here — one copy, in Daniel's wording.

`## Gotchas` at the bottom, matching the one at the bottom of `skills/neon/SKILL.md`, with one entry — @danieltprice's from #82, kept nearly verbatim:

> ### Pooled vs direct connections: use the direct URL for migrations, dumps, and replication
>
> Neon gives you two connection strings for the same database: a **pooled** one (hostname with the `-pooler` suffix) and a **direct/unpooled** one (no `-pooler` suffix). `neon env pull` writes them as `DATABASE_URL` and `DATABASE_URL_UNPOOLED`. The pooled connection routes through PgBouncer in transaction mode, which doesn't support session-level operations. Choose the right one:
>
> - **Pooled (`DATABASE_URL`)** — your application's normal query traffic, especially serverless and connection-per-request workloads.
> - **Direct (`DATABASE_URL_UNPOOLED`)** — schema migrations (Prisma Migrate, Drizzle Kit, Alembic, and others), `pg_dump` / `pg_restore`, logical replication, `LISTEN`/`NOTIFY`, and anything relying on `SET` or other session state.
>
> Running migrations, dumps, or replication over the pooled connection can fail, and never in a way that names pooling: `prepared statement "s0" already exists` from Prisma Migrate, a `SET search_path` that doesn't persist past its own transaction so the next query reports `relation "mytable" does not exist`, or a write intermittently hitting a read-only transaction (`SQLSTATE 25006`) that a pooled backend inherited from an earlier client. Migration tools generally take both strings at once — Prisma's `directUrl` alongside `url` — so point that at the direct one rather than swapping `DATABASE_URL` and losing pooling for the application.

All three symptoms appear as literal strings an agent can match, which is why `SQLSTATE 25006` is spelled out rather than only described. The `directUrl` sentence is there because the plausible wrong fix — swapping `DATABASE_URL` — silently costs the application its pooling.

Frontmatter now lists `schema migrations` in Covers and `"schema migrations"` as a trigger. Without it, a migration prompt matches `neon-postgres-branches` and never loads the connection-type guidance, which defeats the point of consolidating here.

## Differences from #82

Its wording is kept. What changed is where it lives and two points of attribution:

- **Placement.** `neon` is the overview skill, so connection-string choice belongs one level down. `neon-postgres-branches` owns branch mechanics, and repeating the warning at the connection-string step, in the CI pattern, and again in the example is three copies of one fact in a file that loads whole into an agent's context.
- **`DATABASE_URL` is not inherently pooled.** The hostname is what decides it; `DATABASE_URL`/`DATABASE_URL_UNPOOLED` is the convention `neon env pull` and the Neon Functions runtime use, so the entry says that rather than presenting the names as properties of the connection.
- **The two error strings are attributed.** `prepared statement "s0" already exists` is Prisma Migrate specifically, which is how `connection-errors.md` documents it — Prisma Migrate requires a direct connection. The read-only-transaction error names the leaked-`default_transaction_read_only` cause, because its other two documented causes are read replicas and explicit read-only transactions, neither of which involves pooling.

## Also in here

`plugins/neon-postgres/skills/neon-postgres/SKILL.md` is the vendored copy, regenerated by the pre-commit `sync:plugins` hook rather than hand-edited. No version bump: this repo bumps `package.json` in separate release commits that cut accumulated skill changes, and it doesn't use changesets.

## Verification

`npm run validate:ci` passes on this branch, covering `validate:agent-plugin`, `validate:plugins`, `validate:versions`, `validate:skills`, `validate:references`, and the `sync:plugins --check` drift gate. `npx prettier --check` clean. CI `Validate` green.

Every claim in the added text is sourced to `content/docs/connect/connection-pooling.md` and `content/docs/connect/connection-errors.md` in `neondatabase/website` at `a86ae65`. `neon connection-string` returning the direct string by default was checked against the CLI's own `--pooled [default: false]`, not assumed.

## For your attention

- The downstream marketplaces (`openai/plugins`, `xai-org/plugin-marketplace`) vendor their own copies and do not update from this repo. Per its `AGENTS.md` they each need a mirror PR; this PR does not open them.
- `neon-postgres-agent-platforms` in `neondatabase/neon-for-agent-platforms` returns a pooled connection string from `create-project.ts`. #82 flagged it; still open, out of scope here.
- The routing table in `skills/neon/SKILL.md` describes `neon-postgres` as "connections, schemas, queries, and autoscaling" and says nothing about migrations, so an agent routing from the overview skill still leans toward the branches skill. One word in a third file; tracked separately rather than widening this PR.
