### PR TITLE
Document branch logs observability APIs

### DIFF
--- a/plugins/neon-postgres/skills/neon-functions/SKILL.md
+++ b/plugins/neon-postgres/skills/neon-functions/SKILL.md
@@ -508,65 +508,11 @@ Because the function's URL is public, **authenticate before connecting the trans
 
 ### Built-in branch logs
 
-Neon exposes function logs through branch-scoped APIs. Logs currently require a project enrolled in the beta and located in `us-east-2`. The `@neon/sdk` API returns `404` with `reason: "telemetry_not_enabled"` when a branch cannot serve logs.
-
-When the Neon MCP server is available, use its read-only `query_logs`, `list_log_fields`, and `list_log_field_values` tools for interactive agent work. Use the typed `@neon/sdk` interface in application code. Keep queries bounded by a time window and page size:
-
-```typescript
-import { createNeonClient } from "@neon/sdk";
-
-const neon = createNeonClient({ apiKey: process.env.NEON_API_KEY! });
-const query = neon.logs.query(
-  process.env.NEON_PROJECT_ID!,
-  process.env.NEON_BRANCH_ID!,
-  {
-    source: "function",
-    since: "1h",
-    limit: 100,
-    sort_order: "desc",
-  },
-);
-
-const page = await query.page();
-if (page.error) throw page.error;
-
-console.log(page.data.items);
-console.log(page.data.cursor); // pass to query.page(cursor) for the next page
-```
-
-`limit` applies to each page. Use `for await (const record of query)` to stream every page with errors thrown, or `query.all()` to collect every page in a `{ data, error }` result.
-
-With default client settings, `neon.logs.fields(projectId, branchId)` returns `{ data: string[], error }`. `neon.logs.fieldValues(projectId, branchId, fieldName, query?)` returns `{ data: { values, is_truncated }, error }`. When `is_truncated` is true, narrow `since` or `source` before using the values as filters.
-
-An SDK query's time window defaults to one hour and cannot exceed seven days. Supply either `since` or `start_time`, not both. A raw `logql` expression replaces the structured content filters (`source`, service and scope names, severity, message content, and trace ID), but `limit`, `sort_order`, and the time window still apply. Some backends reject `minimum_severity`. `severity_text` is the fallback, but it is a case-sensitive exact match for one stored level, typically uppercase such as `ERROR`; it does not include higher levels.
-
-The SDK and Loki-compatible HTTP API name the same selections differently:
-
-| `@neon/sdk` | Loki-compatible HTTP |
-| --- | --- |
-| `source: "function"` | `entity_type="function"` label |
-| `service_name`, `scope_name`, `trace_id`, `severity_text` | Same-named labels |
-| `minimum_severity` | `severity_text=~` regex covering that level and above |
-| `sort_order: "asc"` / `"desc"` | `direction=forward` / `backward` |
-| `since`, `start_time`, `end_time` | `since`, `start`, `end` |
-
-The SDK's `body_contains` filter maps to Loki's `|=` line filter.
-
-Use the Loki-compatible HTTP API for non-TypeScript clients or when a raw Loki response is required:
-
 ```bash
-curl --get \
-  "https://console.neon.tech/telemetry/v1/projects/${NEON_PROJECT_ID}/branches/${NEON_BRANCH_ID}/loki/api/v1/query_range" \
-  --header "Authorization: Bearer ${NEON_API_KEY}" \
-  --data-urlencode 'query={entity_type="function"}' \
-  --data-urlencode 'since=1h' \
-  --data-urlencode 'limit=100' \
-  --data-urlencode 'direction=backward'
+neon logs query --source function --since 1h
 ```
 
-This endpoint returns the Loki `streams` response envelope. Errors use `{ "status": "error", "error": "..." }`. A query needs at least one stream-label matcher. The API accepts stream selectors and line filters, not aggregations, parsers, or formatting stages. Its `since` parameter uses Go durations such as `1h`; `start` and `end` accept RFC3339 timestamps or Unix nanoseconds.
-
-The HTTP interface has no cursor pagination. `limit` caps one response, and a non-empty `warnings` array means records were dropped. Narrow the time window or filters and query again. Use `/labels` to list stream labels and `/label/{name}/values` to list values for one label. This HTTP surface is separate from the public Neon OpenAPI specification.
+Use the CLI first. For field discovery, MCP fallback, `@neon/sdk`, Loki-compatible integration endpoints, and availability, see the parent `neon` skill's **Observability** section.
 
 ### Application instrumentation
 

--- a/plugins/neon-postgres/skills/neon-functions/SKILL.md
+++ b/plugins/neon-postgres/skills/neon-functions/SKILL.md
@@ -11,7 +11,8 @@ description: >-
   function", "deploy an API", "long-running function", "streaming agent",
   "SSE server", "WebSocket server", "webhook handler", "MCP server",
   "run code next to my database", "function that won't time out",
-  "Neon Functions", and "Neon Compute".
+  "function logs", "query logs", "observability", "Neon Functions", and
+  "Neon Compute".
 metadata:
   parent: neon
 ---
@@ -503,13 +504,13 @@ app.all("/mcp", async (c) => {
 
 Because the function's URL is public, **authenticate before connecting the transport** — [Better Auth](https://better-auth.com) covers both OAuth (its MCP plugin makes your app the authorization server so third-party clients self-authorize per the MCP spec) and a simpler API-key / session-JWT check for your own callers. [references/mcp.md](https://neon.com/docs/ai/skills/neon-functions/references/mcp.md) has the full pattern — server with Postgres-backed tools via Drizzle, both Better Auth auth options, and testing with `mcporter` / `add-mcp`.
 
-## Observability
+## Integrations and Observability
 
 ### Built-in branch logs
 
-Neon exposes function logs through branch-scoped APIs. Logs currently require a project enrolled in the beta and located in `us-east-2`; other branches can return `404` with `reason: "telemetry_not_enabled"`.
+Neon exposes function logs through branch-scoped APIs. Logs currently require a project enrolled in the beta and located in `us-east-2`. The `@neon/sdk` API returns `404` with `reason: "telemetry_not_enabled"` when a branch cannot serve logs.
 
-Use the typed `@neon/sdk` interface for application code and agents. Keep queries bounded by a time window and page size:
+When the Neon MCP server is available, use its read-only `query_logs`, `list_log_fields`, and `list_log_field_values` tools for interactive agent work. Use the typed `@neon/sdk` interface in application code. Keep queries bounded by a time window and page size:
 
 ```typescript
 import { createNeonClient } from "@neon/sdk";
@@ -533,9 +534,23 @@ console.log(page.data.items);
 console.log(page.data.cursor); // pass to query.page(cursor) for the next page
 ```
 
-`neon.logs.fields(projectId, branchId)` lists fields observed on the branch. `neon.logs.fieldValues(projectId, branchId, fieldName, query?)` lists values for one of those fields and returns `is_truncated` with the values. `neon.logs.query()` also accepts a raw `logql` expression when the structured filters cannot express a query. Do not combine `logql` with structured content filters.
+`limit` applies to each page. Use `for await (const record of query)` to stream every page with errors thrown, or `query.all()` to collect every page in a `{ data, error }` result.
 
-The same logs are available through a Loki-compatible HTTP API for direct LogQL access:
+With default client settings, `neon.logs.fields(projectId, branchId)` returns `{ data: string[], error }`. `neon.logs.fieldValues(projectId, branchId, fieldName, query?)` returns `{ data: { values, is_truncated }, error }`. When `is_truncated` is true, narrow `since` or `source` before using the values as filters.
+
+The time window defaults to one hour and cannot exceed seven days. Supply either `since` or `start_time`, not both. A raw `logql` expression replaces the structured content filters (`source`, service and scope names, severity, message content, and trace ID), but `limit`, `sort_order`, and the time window still apply. Some backends reject `minimum_severity`; use `severity_text` when that happens.
+
+The SDK and Loki-compatible HTTP API name the same selections differently:
+
+| `@neon/sdk` | Loki-compatible HTTP |
+| --- | --- |
+| `source: "function"` | `entity_type="function"` label |
+| `service_name`, `scope_name`, `trace_id`, `severity_text` | Same-named labels |
+| `minimum_severity` | `severity_text=~` regex covering that level and above |
+| `body_contains` | `\|=` line filter |
+| `sort_order: "asc"` / `"desc"` | `direction=forward` / `backward` |
+
+Use the Loki-compatible HTTP API for non-TypeScript clients or when a raw Loki response is required:
 
 ```bash
 curl --get \
@@ -547,7 +562,7 @@ curl --get \
   --data-urlencode 'direction=backward'
 ```
 
-This endpoint returns the Loki `streams` response envelope. It accepts stream selectors and line filters, not aggregations, parsers, or formatting stages. Use `/labels` to list stream labels and `/label/{name}/values` to list values for one label. This HTTP surface is separate from the public Neon OpenAPI specification.
+This endpoint returns the Loki `streams` response envelope. Errors use `{ "status": "error", "error": "..." }`. A query needs at least one stream-label matcher. The API accepts stream selectors and line filters, not aggregations, parsers, or formatting stages. Use `/labels` to list stream labels and `/label/{name}/values` to list values for one label. This HTTP surface is separate from the public Neon OpenAPI specification.
 
 ### Application instrumentation
 

--- a/plugins/neon-postgres/skills/neon-functions/SKILL.md
+++ b/plugins/neon-postgres/skills/neon-functions/SKILL.md
@@ -503,7 +503,53 @@ app.all("/mcp", async (c) => {
 
 Because the function's URL is public, **authenticate before connecting the transport** — [Better Auth](https://better-auth.com) covers both OAuth (its MCP plugin makes your app the authorization server so third-party clients self-authorize per the MCP spec) and a simpler API-key / session-JWT check for your own callers. [references/mcp.md](https://neon.com/docs/ai/skills/neon-functions/references/mcp.md) has the full pattern — server with Postgres-backed tools via Drizzle, both Better Auth auth options, and testing with `mcporter` / `add-mcp`.
 
-## Integrations and Observability
+## Observability
+
+### Built-in branch logs
+
+Neon exposes function logs through branch-scoped APIs. Logs are a beta feature and currently work only for projects in `us-east-2`.
+
+Use the typed `@neon/sdk` interface for application code and agents. Keep queries bounded by a time window and page size:
+
+```typescript
+import { createNeonClient } from "@neon/sdk";
+
+const neon = createNeonClient({ apiKey: process.env.NEON_API_KEY! });
+const query = neon.logs.query(
+  process.env.NEON_PROJECT_ID!,
+  process.env.NEON_BRANCH_ID!,
+  {
+    source: "function",
+    since: "1h",
+    limit: 100,
+    sort_order: "desc",
+  },
+);
+
+const page = await query.page();
+if (page.error) throw page.error;
+
+console.log(page.data.items);
+console.log(page.data.cursor); // pass to query.page(cursor) for the next page
+```
+
+`neon.logs.fields(projectId, branchId)` lists fields observed on the branch. `neon.logs.fieldValues(projectId, branchId, fieldName, query?)` lists values for one of those fields and returns `is_truncated` with the values. `neon.logs.query()` also accepts a raw `logql` expression when the structured filters cannot express a query. Do not combine `logql` with structured content filters.
+
+The same logs are available through a Loki-compatible HTTP API for direct LogQL access:
+
+```bash
+curl --get \
+  "https://console.neon.tech/telemetry/v1/projects/${NEON_PROJECT_ID}/branches/${NEON_BRANCH_ID}/loki/api/v1/query_range" \
+  --header "Authorization: Bearer ${NEON_API_KEY}" \
+  --data-urlencode 'query={entity_type="function"}' \
+  --data-urlencode 'since=1h' \
+  --data-urlencode 'limit=100' \
+  --data-urlencode 'direction=backward'
+```
+
+This endpoint returns the Loki `streams` response envelope. It accepts stream selectors and line filters, not aggregations, parsers, or formatting stages. Use `/labels` to list stream labels and `/label/{name}/values` to list values for one label. This HTTP surface is separate from the public Neon OpenAPI specification.
+
+### Application instrumentation
 
 A function is a long-lived Node.js process running a web-standard request/response handler, so standard Node integration SDKs work unchanged. Initialize them once at module load, gated on an env var so local dev and unconfigured branches stay a no-op, and pass secrets via `--env` or `neon.ts` `env`.
 

--- a/plugins/neon-postgres/skills/neon-functions/SKILL.md
+++ b/plugins/neon-postgres/skills/neon-functions/SKILL.md
@@ -507,7 +507,7 @@ Because the function's URL is public, **authenticate before connecting the trans
 
 ### Built-in branch logs
 
-Neon exposes function logs through branch-scoped APIs. Logs are a beta feature and currently work only for projects in `us-east-2`.
+Neon exposes function logs through branch-scoped APIs. Logs currently require a project enrolled in the beta and located in `us-east-2`; other branches can return `404` with `reason: "telemetry_not_enabled"`.
 
 Use the typed `@neon/sdk` interface for application code and agents. Keep queries bounded by a time window and page size:
 

--- a/plugins/neon-postgres/skills/neon-functions/SKILL.md
+++ b/plugins/neon-postgres/skills/neon-functions/SKILL.md
@@ -538,7 +538,7 @@ console.log(page.data.cursor); // pass to query.page(cursor) for the next page
 
 With default client settings, `neon.logs.fields(projectId, branchId)` returns `{ data: string[], error }`. `neon.logs.fieldValues(projectId, branchId, fieldName, query?)` returns `{ data: { values, is_truncated }, error }`. When `is_truncated` is true, narrow `since` or `source` before using the values as filters.
 
-The time window defaults to one hour and cannot exceed seven days. Supply either `since` or `start_time`, not both. A raw `logql` expression replaces the structured content filters (`source`, service and scope names, severity, message content, and trace ID), but `limit`, `sort_order`, and the time window still apply. Some backends reject `minimum_severity`; use `severity_text` when that happens.
+An SDK query's time window defaults to one hour and cannot exceed seven days. Supply either `since` or `start_time`, not both. A raw `logql` expression replaces the structured content filters (`source`, service and scope names, severity, message content, and trace ID), but `limit`, `sort_order`, and the time window still apply. Some backends reject `minimum_severity`. `severity_text` is the fallback, but it is a case-sensitive exact match for one stored level, typically uppercase such as `ERROR`; it does not include higher levels.
 
 The SDK and Loki-compatible HTTP API name the same selections differently:
 
@@ -547,8 +547,10 @@ The SDK and Loki-compatible HTTP API name the same selections differently:
 | `source: "function"` | `entity_type="function"` label |
 | `service_name`, `scope_name`, `trace_id`, `severity_text` | Same-named labels |
 | `minimum_severity` | `severity_text=~` regex covering that level and above |
-| `body_contains` | `\|=` line filter |
 | `sort_order: "asc"` / `"desc"` | `direction=forward` / `backward` |
+| `since`, `start_time`, `end_time` | `since`, `start`, `end` |
+
+The SDK's `body_contains` filter maps to Loki's `|=` line filter.
 
 Use the Loki-compatible HTTP API for non-TypeScript clients or when a raw Loki response is required:
 
@@ -562,7 +564,9 @@ curl --get \
   --data-urlencode 'direction=backward'
 ```
 
-This endpoint returns the Loki `streams` response envelope. Errors use `{ "status": "error", "error": "..." }`. A query needs at least one stream-label matcher. The API accepts stream selectors and line filters, not aggregations, parsers, or formatting stages. Use `/labels` to list stream labels and `/label/{name}/values` to list values for one label. This HTTP surface is separate from the public Neon OpenAPI specification.
+This endpoint returns the Loki `streams` response envelope. Errors use `{ "status": "error", "error": "..." }`. A query needs at least one stream-label matcher. The API accepts stream selectors and line filters, not aggregations, parsers, or formatting stages. Its `since` parameter uses Go durations such as `1h`; `start` and `end` accept RFC3339 timestamps or Unix nanoseconds.
+
+The HTTP interface has no cursor pagination. `limit` caps one response, and a non-empty `warnings` array means records were dropped. Narrow the time window or filters and query again. Use `/labels` to list stream labels and `/label/{name}/values` to list values for one label. This HTTP surface is separate from the public Neon OpenAPI specification.
 
 ### Application instrumentation
 

--- a/plugins/neon-postgres/skills/neon-functions/SKILL.md
+++ b/plugins/neon-postgres/skills/neon-functions/SKILL.md
@@ -508,10 +508,10 @@ Because the function's URL is public, **authenticate before connecting the trans
 ### Built-in branch logs
 
 ```bash
-neon logs query --source function --since 1h
+neon logs query --branch production --source function --since 1h
 ```
 
-Use the CLI first. For the required CLI version, field discovery, MCP fallback, `@neon/sdk`, Loki-compatible integration endpoints, and availability, see the parent `neon` skill's **Observability** section.
+Functions is one of the two sources branch logs cover today, alongside Object Storage. Logs are scoped to a single branch, so pass `--branch` when the deployed function isn't on the branch you're checked out on. Everything else about logs — the required CLI version, filters, the SDK, and Loki export — is in the parent `neon` skill's **Observability** section.
 
 ### Application instrumentation
 

--- a/plugins/neon-postgres/skills/neon-functions/SKILL.md
+++ b/plugins/neon-postgres/skills/neon-functions/SKILL.md
@@ -511,7 +511,7 @@ Because the function's URL is public, **authenticate before connecting the trans
 neon logs query --branch production --source function --since 1h
 ```
 
-Functions is one of the two sources branch logs cover today, alongside Object Storage. Logs are scoped to a single branch, so pass `--branch` when the deployed function isn't on the branch you're checked out on. Everything else about logs — the required CLI version, filters, the SDK, and Loki export — is in the parent `neon` skill's **Observability** section.
+Functions is one of the two sources branch logs cover today, alongside Object Storage. Logs are scoped to a single branch, so pass `--branch` when the deployed function isn't on the branch you're checked out on. Everything else about logs — the required CLI version, filters, the SDK, and the Loki-compatible read API — is in the parent `neon` skill's **Observability** section.
 
 ### Application instrumentation
 

--- a/plugins/neon-postgres/skills/neon-functions/SKILL.md
+++ b/plugins/neon-postgres/skills/neon-functions/SKILL.md
@@ -11,8 +11,7 @@ description: >-
   function", "deploy an API", "long-running function", "streaming agent",
   "SSE server", "WebSocket server", "webhook handler", "MCP server",
   "run code next to my database", "function that won't time out",
-  "function logs", "query logs", "observability", "Neon Functions", and
-  "Neon Compute".
+  "function logs", "Neon Functions", and "Neon Compute".
 metadata:
   parent: neon
 ---

--- a/plugins/neon-postgres/skills/neon-functions/SKILL.md
+++ b/plugins/neon-postgres/skills/neon-functions/SKILL.md
@@ -511,7 +511,7 @@ Because the function's URL is public, **authenticate before connecting the trans
 neon logs query --source function --since 1h
 ```
 
-Use the CLI first. For field discovery, MCP fallback, `@neon/sdk`, Loki-compatible integration endpoints, and availability, see the parent `neon` skill's **Observability** section.
+Use the CLI first. For the required CLI version, field discovery, MCP fallback, `@neon/sdk`, Loki-compatible integration endpoints, and availability, see the parent `neon` skill's **Observability** section.
 
 ### Application instrumentation
 

--- a/plugins/neon-postgres/skills/neon-object-storage/SKILL.md
+++ b/plugins/neon-postgres/skills/neon-object-storage/SKILL.md
@@ -202,7 +202,7 @@ The canonical pattern: an agent generates an image → `PutObject` into the `ima
 neon logs query --branch production --source storage --since 1h
 ```
 
-Storage is one of the two sources branch logs cover today, alongside Neon Functions. Logs are scoped to a single branch, so pass `--branch` when the bucket you're debugging isn't on the branch you're checked out on. Everything else about logs — the required CLI version, filters, the SDK, and Loki export — is in the parent `neon` skill's **Observability** section.
+Storage is one of the two sources branch logs cover today, alongside Neon Functions. Logs are scoped to a single branch, so pass `--branch` when the bucket you're debugging isn't on the branch you're checked out on. Everything else about logs — the required CLI version, filters, the SDK, and the Loki-compatible read API — is in the parent `neon` skill's **Observability** section.
 
 ## Neon Documentation
 

--- a/plugins/neon-postgres/skills/neon-object-storage/SKILL.md
+++ b/plugins/neon-postgres/skills/neon-object-storage/SKILL.md
@@ -9,8 +9,9 @@ description: >-
   want to add a separate storage provider like AWS S3, Cloudflare R2, or
   Supabase Storage. Triggers include "object storage", "bucket", "blob
   storage", "file storage", "store uploads/images/files", "S3-compatible
-  storage", "presigned URL", "where do I put files", "Neon Object Storage",
-  "Neon Storage", and "storage that branches with my database".
+  storage", "presigned URL", "where do I put files", "storage logs",
+  "Neon Object Storage", "Neon Storage", and "storage that branches with my
+  database".
 metadata:
   parent: neon
 ---
@@ -194,6 +195,14 @@ The canonical pattern: an agent generates an image → `PutObject` into the `ima
 ## CLI Bucket and Object Commands
 
 `neon` also has first-class bucket/object commands (`neon bucket create|list|delete`, `neon bucket object put|get|list|delete`) for scripting and one-off operations.
+
+## Built-in Branch Logs
+
+```bash
+neon logs query --source storage --since 1h
+```
+
+Storage is one of the two sources branch logs cover today, alongside Neon Functions. Use the CLI first. For the required CLI version, field discovery, MCP fallback, `@neon/sdk`, Loki-compatible integration endpoints, and availability, see the parent `neon` skill's **Observability** section.
 
 ## Neon Documentation
 

--- a/plugins/neon-postgres/skills/neon-object-storage/SKILL.md
+++ b/plugins/neon-postgres/skills/neon-object-storage/SKILL.md
@@ -10,8 +10,8 @@ description: >-
   Supabase Storage. Triggers include "object storage", "bucket", "blob
   storage", "file storage", "store uploads/images/files", "S3-compatible
   storage", "presigned URL", "where do I put files", "storage logs",
-  "Neon Object Storage", "Neon Storage", and "storage that branches with my
-  database".
+  "bucket logs", "Neon Object Storage", "Neon Storage", and "storage that
+  branches with my database".
 metadata:
   parent: neon
 ---
@@ -199,10 +199,10 @@ The canonical pattern: an agent generates an image → `PutObject` into the `ima
 ## Built-in Branch Logs
 
 ```bash
-neon logs query --source storage --since 1h
+neon logs query --branch production --source storage --since 1h
 ```
 
-Storage is one of the two sources branch logs cover today, alongside Neon Functions. Use the CLI first. For the required CLI version, field discovery, MCP fallback, `@neon/sdk`, Loki-compatible integration endpoints, and availability, see the parent `neon` skill's **Observability** section.
+Storage is one of the two sources branch logs cover today, alongside Neon Functions. Logs are scoped to a single branch, so pass `--branch` when the bucket you're debugging isn't on the branch you're checked out on. Everything else about logs — the required CLI version, filters, the SDK, and Loki export — is in the parent `neon` skill's **Observability** section.
 
 ## Neon Documentation
 

--- a/plugins/neon-postgres/skills/neon/SKILL.md
+++ b/plugins/neon-postgres/skills/neon/SKILL.md
@@ -360,7 +360,7 @@ For reading env you _already_ have on disk (typed and validated against your `ne
 
 ## Observability
 
-Neon exposes branch-scoped logs. **Today they cover Neon Functions and Object Storage only.** Postgres computes and the AI Gateway are coming; until then, neither emits records. Logs are region-gated like the other services above — only `us-east-2` is enabled today, and a branch in any other region answers `404` with reason `telemetry_not_enabled` rather than an empty result.
+Neon exposes branch-scoped logs. **Today they cover Neon Functions and Object Storage only.** Postgres computes and the AI Gateway are coming; until then, neither emits records. Logs are region-gated like the other beta services above — only `us-east-2` is enabled today, and a branch in any other region answers `404` with reason `telemetry_not_enabled` rather than an empty result.
 
 Use Neon CLI 3.1 or newer first. **Decide which branch you are querying.** Without `--branch`, the CLI uses the branch pinned in `.neon`, or the project's default branch when the workspace isn't linked. A deployed function or bucket usually lives on a different branch than the one checked out for development, so an empty result is more often the wrong branch than a missing log.
 

--- a/plugins/neon-postgres/skills/neon/SKILL.md
+++ b/plugins/neon-postgres/skills/neon/SKILL.md
@@ -359,18 +359,19 @@ For reading env you _already_ have on disk (typed and validated against your `ne
 
 ## Observability
 
-Neon exposes branch-scoped logs from Functions, Object Storage, and Postgres computes. Logs require beta enrollment and a project in `us-east-2`; an unavailable branch returns `404` with reason `telemetry_not_enabled`.
+Neon exposes branch-scoped logs. **Today they cover Neon Functions and Object Storage only.** Postgres computes and the AI Gateway are coming; until then, neither emits records. Logs require beta enrollment and a project in `us-east-2`; an unavailable branch returns `404` with reason `telemetry_not_enabled`.
 
 Use Neon CLI 3.1 or newer first:
 
 ```bash
 neon logs query --since 1h
 neon logs query --source function --since 1h
+neon logs query --source storage --since 1h
 neon logs fields
 neon logs field-values service_name --since 1h
 ```
 
-`--source` accepts `function`, `storage`, or `pg_endpoint`. Use `--logql` instead of the structured filters for a raw stream selector or line filter; run `neon logs --help` for the full filter and pagination interface.
+`--source` accepts `function`, `storage`, and `pg_endpoint`, but only `function` and `storage` return records today — `pg_endpoint` is accepted and comes back empty until Postgres logs ship. Use `--logql` instead of the structured filters for a raw stream selector or line filter; run `neon logs --help` for the full filter and pagination interface.
 
 If the CLI is unavailable, fall back to the Neon MCP server's read-only `query_logs`, `list_log_fields`, and `list_log_field_values` tools. In TypeScript applications, use `@neon/sdk`: `neon.logs.query`, `neon.logs.fields`, and `neon.logs.fieldValues`.
 

--- a/plugins/neon-postgres/skills/neon/SKILL.md
+++ b/plugins/neon-postgres/skills/neon/SKILL.md
@@ -358,7 +358,7 @@ For reading env you _already_ have on disk (typed and validated against your `ne
 
 ## Observability
 
-Neon exposes branch-scoped service logs through a typed SDK and a Loki-compatible HTTP API. Logs are a beta feature and currently work only for projects in `us-east-2`.
+Neon exposes branch-scoped service logs through a typed SDK and a Loki-compatible HTTP API. Logs currently require a project enrolled in the beta and located in `us-east-2`; other branches can return `404` with `reason: "telemetry_not_enabled"`.
 
 ### Query logs with `@neon/sdk`
 
@@ -386,7 +386,7 @@ console.log(page.data.items);
 console.log(page.data.cursor); // pass to query.page(cursor) for the next page
 ```
 
-Use `source` to select `function`, `storage`, or `pg_endpoint` records. Other structured filters include `service_name`, `scope_name`, severity, message content, and trace ID. `neon.logs.fields(projectId, branchId)` discovers observed fields. `neon.logs.fieldValues(projectId, branchId, fieldName, query?)` discovers values and reports whether the result was truncated. For selections the structured filters cannot express, `neon.logs.query()` accepts `logql`; do not combine it with structured content filters.
+Use `source` to select `function` or `storage` records. Other structured filters include `service_name`, `scope_name`, severity, message content, and trace ID. `neon.logs.fields(projectId, branchId)` discovers observed fields. `neon.logs.fieldValues(projectId, branchId, fieldName, query?)` discovers values and reports whether the result was truncated. For selections the structured filters cannot express, `neon.logs.query()` accepts `logql`; do not combine it with structured content filters.
 
 ### Query the Loki-compatible HTTP API
 

--- a/plugins/neon-postgres/skills/neon/SKILL.md
+++ b/plugins/neon-postgres/skills/neon/SKILL.md
@@ -359,73 +359,36 @@ For reading env you _already_ have on disk (typed and validated against your `ne
 
 ## Observability
 
-Neon exposes branch-scoped service logs through a typed SDK and a Loki-compatible HTTP API. Logs currently require a project enrolled in the beta and located in `us-east-2`. The `@neon/sdk` API returns `404` with `reason: "telemetry_not_enabled"` when a branch cannot serve logs.
+Neon exposes branch-scoped logs from Functions, Object Storage, and Postgres computes. Logs require beta enrollment and a project in `us-east-2`; an unavailable branch returns `404` with reason `telemetry_not_enabled`.
 
-When the Neon MCP server is available, use its read-only `query_logs`, `list_log_fields`, and `list_log_field_values` tools for interactive agent work.
-
-### Query logs with `@neon/sdk`
-
-Use `neon.logs.query()` in application code. It returns a lazy paginated result:
-
-```typescript
-import { createNeonClient } from "@neon/sdk";
-
-const neon = createNeonClient({ apiKey: process.env.NEON_API_KEY! });
-const query = neon.logs.query(
-  process.env.NEON_PROJECT_ID!,
-  process.env.NEON_BRANCH_ID!,
-  {
-    source: "function",
-    since: "1h",
-    limit: 100,
-    sort_order: "desc",
-  },
-);
-
-const page = await query.page();
-if (page.error) throw page.error;
-
-console.log(page.data.items);
-console.log(page.data.cursor); // pass to query.page(cursor) for the next page
-```
-
-`limit` applies to each page. Use `for await (const record of query)` to stream every page with errors thrown, or `query.all()` to collect every page in a `{ data, error }` result.
-
-With default client settings, `neon.logs.fields(projectId, branchId)` returns `{ data: string[], error }`. `neon.logs.fieldValues(projectId, branchId, fieldName, query?)` returns `{ data: { values, is_truncated }, error }`. When `is_truncated` is true, narrow `since` or `source` before using the values as filters.
-
-Use `source` to select `function` or `storage` records. The SDK type also accepts `pg_endpoint`, but that source has not been observed emitting records. Other structured filters include `service_name`, `scope_name`, `severity_text`, `minimum_severity`, `body_contains`, and `trace_id`. Some backends reject `minimum_severity`. `severity_text` is the fallback, but it is a case-sensitive exact match for one stored level, typically uppercase such as `ERROR`; it does not include higher levels.
-
-An SDK query's time window defaults to one hour and cannot exceed seven days. Supply either `since` or `start_time`, not both. A raw `logql` expression replaces the structured content filters, but `limit`, `sort_order`, and the time window still apply.
-
-The SDK and Loki-compatible HTTP API name the same selections differently:
-
-| `@neon/sdk` | Loki-compatible HTTP |
-| --- | --- |
-| `source: "function"` | `entity_type="function"` label |
-| `service_name`, `scope_name`, `trace_id`, `severity_text` | Same-named labels |
-| `minimum_severity` | `severity_text=~` regex covering that level and above |
-| `sort_order: "asc"` / `"desc"` | `direction=forward` / `backward` |
-| `since`, `start_time`, `end_time` | `since`, `start`, `end` |
-
-The SDK's `body_contains` filter maps to Loki's `|=` line filter.
-
-### Query the Loki-compatible HTTP API
-
-Use the direct HTTP surface for non-TypeScript clients or when a raw Loki response is required:
+Use the CLI first:
 
 ```bash
-curl --get \
-  "https://console.neon.tech/telemetry/v1/projects/${NEON_PROJECT_ID}/branches/${NEON_BRANCH_ID}/loki/api/v1/query_range" \
-  --header "Authorization: Bearer ${NEON_API_KEY}" \
-  --data-urlencode 'query={entity_type="function"}' \
-  --data-urlencode 'since=1h' \
-  --data-urlencode 'limit=100' \
-  --data-urlencode 'direction=backward'
+neon logs query --since 1h
+neon logs query --source function --since 1h
+neon logs fields
+neon logs field-values service_name --since 1h
 ```
 
-The response uses the Loki `streams` envelope. Errors use `{ "status": "error", "error": "..." }`. A query needs at least one stream-label matcher. This API accepts stream selectors and line filters, not aggregations, parsers, or formatting stages. Its `since` parameter uses Go durations such as `1h`; `start` and `end` accept RFC3339 timestamps or Unix nanoseconds.
+`--source` accepts `function`, `storage`, or `pg_endpoint`. Use `--logql` for a raw stream selector or line filter; run `neon logs --help` for the full filter and pagination interface.
 
-The HTTP interface has no cursor pagination. `limit` caps one response, and a non-empty `warnings` array means records were dropped. Narrow the time window or filters and query again. Use `/labels` to list stream labels and `/label/{name}/values` to list values for one label. This HTTP surface is separate from the public Neon OpenAPI specification.
+If the CLI is unavailable, fall back to the Neon MCP server's read-only `query_logs`, `list_log_fields`, and `list_log_field_values` tools. In TypeScript applications, use `@neon/sdk`: `neon.logs.query()`, `neon.logs.fields()`, and `neon.logs.fieldValues()`.
+
+### Loki-compatible read API
+
+For Loki export or integration, authenticate with `Authorization: Bearer <NEON_API_KEY>` and use this branch-scoped base URL:
+
+```text
+https://console.neon.tech/telemetry/v1/projects/{projectId}/branches/{branchId}/loki
+```
+
+The available endpoints are:
+
+- `GET /api/v1/query_range`
+- `GET /api/v1/labels`
+- `GET /api/v1/label/{name}/values`
+
+This is a read-only Loki-compatible subset, not a push endpoint or complete Loki deployment. `query_range` supports LogQL stream selectors and line filters, plus `since` or `start`/`end`, `limit`, and `direction`; it does not support aggregations, parsers, or formatting stages.
 
 ## Manage Neon Resources
 

--- a/plugins/neon-postgres/skills/neon/SKILL.md
+++ b/plugins/neon-postgres/skills/neon/SKILL.md
@@ -361,9 +361,11 @@ For reading env you _already_ have on disk (typed and validated against your `ne
 
 Neon exposes branch-scoped service logs through a typed SDK and a Loki-compatible HTTP API. Logs currently require a project enrolled in the beta and located in `us-east-2`. The `@neon/sdk` API returns `404` with `reason: "telemetry_not_enabled"` when a branch cannot serve logs.
 
+When the Neon MCP server is available, use its read-only `query_logs`, `list_log_fields`, and `list_log_field_values` tools for interactive agent work.
+
 ### Query logs with `@neon/sdk`
 
-When the Neon MCP server is available, use its read-only `query_logs`, `list_log_fields`, and `list_log_field_values` tools for interactive agent work. Use `neon.logs.query()` in application code. It returns a lazy paginated result:
+Use `neon.logs.query()` in application code. It returns a lazy paginated result:
 
 ```typescript
 import { createNeonClient } from "@neon/sdk";
@@ -391,9 +393,9 @@ console.log(page.data.cursor); // pass to query.page(cursor) for the next page
 
 With default client settings, `neon.logs.fields(projectId, branchId)` returns `{ data: string[], error }`. `neon.logs.fieldValues(projectId, branchId, fieldName, query?)` returns `{ data: { values, is_truncated }, error }`. When `is_truncated` is true, narrow `since` or `source` before using the values as filters.
 
-Use `source` to select `function` or `storage` records. The SDK type also accepts `pg_endpoint`, but that source has not been observed emitting records. Other structured filters include `service_name`, `scope_name`, `severity_text`, `minimum_severity`, `body_contains`, and `trace_id`. Some backends reject `minimum_severity`; use `severity_text` when that happens.
+Use `source` to select `function` or `storage` records. The SDK type also accepts `pg_endpoint`, but that source has not been observed emitting records. Other structured filters include `service_name`, `scope_name`, `severity_text`, `minimum_severity`, `body_contains`, and `trace_id`. Some backends reject `minimum_severity`. `severity_text` is the fallback, but it is a case-sensitive exact match for one stored level, typically uppercase such as `ERROR`; it does not include higher levels.
 
-The time window defaults to one hour and cannot exceed seven days. Supply either `since` or `start_time`, not both. A raw `logql` expression replaces the structured content filters, but `limit`, `sort_order`, and the time window still apply.
+An SDK query's time window defaults to one hour and cannot exceed seven days. Supply either `since` or `start_time`, not both. A raw `logql` expression replaces the structured content filters, but `limit`, `sort_order`, and the time window still apply.
 
 The SDK and Loki-compatible HTTP API name the same selections differently:
 
@@ -402,8 +404,10 @@ The SDK and Loki-compatible HTTP API name the same selections differently:
 | `source: "function"` | `entity_type="function"` label |
 | `service_name`, `scope_name`, `trace_id`, `severity_text` | Same-named labels |
 | `minimum_severity` | `severity_text=~` regex covering that level and above |
-| `body_contains` | `\|=` line filter |
 | `sort_order: "asc"` / `"desc"` | `direction=forward` / `backward` |
+| `since`, `start_time`, `end_time` | `since`, `start`, `end` |
+
+The SDK's `body_contains` filter maps to Loki's `|=` line filter.
 
 ### Query the Loki-compatible HTTP API
 
@@ -419,7 +423,9 @@ curl --get \
   --data-urlencode 'direction=backward'
 ```
 
-The response uses the Loki `streams` envelope. Errors use `{ "status": "error", "error": "..." }`. A query needs at least one stream-label matcher. This API accepts stream selectors and line filters, not aggregations, parsers, or formatting stages. Use `/labels` to list stream labels and `/label/{name}/values` to list values for one label. This HTTP surface is separate from the public Neon OpenAPI specification.
+The response uses the Loki `streams` envelope. Errors use `{ "status": "error", "error": "..." }`. A query needs at least one stream-label matcher. This API accepts stream selectors and line filters, not aggregations, parsers, or formatting stages. Its `since` parameter uses Go durations such as `1h`; `start` and `end` accept RFC3339 timestamps or Unix nanoseconds.
+
+The HTTP interface has no cursor pagination. `limit` caps one response, and a non-empty `warnings` array means records were dropped. Narrow the time window or filters and query again. Use `/labels` to list stream labels and `/label/{name}/values` to list values for one label. This HTTP surface is separate from the public Neon OpenAPI specification.
 
 ## Manage Neon Resources
 

--- a/plugins/neon-postgres/skills/neon/SKILL.md
+++ b/plugins/neon-postgres/skills/neon/SKILL.md
@@ -356,6 +356,54 @@ When an agent should not write a local `.env`, instruct it (for example in your 
 
 For reading env you _already_ have on disk (typed and validated against your `neon.ts`), use `parseEnv` — see [Type-safe env vars with parseEnv](#type-safe-env-vars-with-parseenv) above.
 
+## Observability
+
+Neon exposes branch-scoped service logs through a typed SDK and a Loki-compatible HTTP API. Logs are a beta feature and currently work only for projects in `us-east-2`.
+
+### Query logs with `@neon/sdk`
+
+Use `neon.logs.query()` for bounded log queries. It returns a lazy paginated result:
+
+```typescript
+import { createNeonClient } from "@neon/sdk";
+
+const neon = createNeonClient({ apiKey: process.env.NEON_API_KEY! });
+const query = neon.logs.query(
+  process.env.NEON_PROJECT_ID!,
+  process.env.NEON_BRANCH_ID!,
+  {
+    source: "function",
+    since: "1h",
+    limit: 100,
+    sort_order: "desc",
+  },
+);
+
+const page = await query.page();
+if (page.error) throw page.error;
+
+console.log(page.data.items);
+console.log(page.data.cursor); // pass to query.page(cursor) for the next page
+```
+
+Use `source` to select `function`, `storage`, or `pg_endpoint` records. Other structured filters include `service_name`, `scope_name`, severity, message content, and trace ID. `neon.logs.fields(projectId, branchId)` discovers observed fields. `neon.logs.fieldValues(projectId, branchId, fieldName, query?)` discovers values and reports whether the result was truncated. For selections the structured filters cannot express, `neon.logs.query()` accepts `logql`; do not combine it with structured content filters.
+
+### Query the Loki-compatible HTTP API
+
+Use the direct HTTP surface when you need LogQL or a raw Loki response:
+
+```bash
+curl --get \
+  "https://console.neon.tech/telemetry/v1/projects/${NEON_PROJECT_ID}/branches/${NEON_BRANCH_ID}/loki/api/v1/query_range" \
+  --header "Authorization: Bearer ${NEON_API_KEY}" \
+  --data-urlencode 'query={entity_type="function"}' \
+  --data-urlencode 'since=1h' \
+  --data-urlencode 'limit=100' \
+  --data-urlencode 'direction=backward'
+```
+
+The response uses the Loki `streams` envelope. This API accepts stream selectors and line filters, not aggregations, parsers, or formatting stages. Use `/labels` to list stream labels and `/label/{name}/values` to list values for one label. This HTTP surface is separate from the public Neon OpenAPI specification.
+
 ## Manage Neon Resources
 
 Recommended: Use `@neon/sdk` to manage Neon resources programmatically, such as creating projects, branches, and snapshots for dev scripts, CI/CD automations, and platforms building on top of Neon.

--- a/plugins/neon-postgres/skills/neon/SKILL.md
+++ b/plugins/neon-postgres/skills/neon/SKILL.md
@@ -7,7 +7,8 @@ description: >-
   up the CLI or MCP server, and follow the branch-first workflow. Use when "Neon"
   or "Lakebase Postgres" is mentioned, or when any of its individual capabilities
   are the trigger: "object storage" or "S3", "buckets", "serverless functions",
-  "AI gateway", "call an LLM", "postgres", "database", or "backend".
+  "AI gateway", "call an LLM", "branch logs", "query logs", "observability",
+  "telemetry", "postgres", "database", or "backend".
 ---
 
 # Neon
@@ -358,11 +359,11 @@ For reading env you _already_ have on disk (typed and validated against your `ne
 
 ## Observability
 
-Neon exposes branch-scoped service logs through a typed SDK and a Loki-compatible HTTP API. Logs currently require a project enrolled in the beta and located in `us-east-2`; other branches can return `404` with `reason: "telemetry_not_enabled"`.
+Neon exposes branch-scoped service logs through a typed SDK and a Loki-compatible HTTP API. Logs currently require a project enrolled in the beta and located in `us-east-2`. The `@neon/sdk` API returns `404` with `reason: "telemetry_not_enabled"` when a branch cannot serve logs.
 
 ### Query logs with `@neon/sdk`
 
-Use `neon.logs.query()` for bounded log queries. It returns a lazy paginated result:
+When the Neon MCP server is available, use its read-only `query_logs`, `list_log_fields`, and `list_log_field_values` tools for interactive agent work. Use `neon.logs.query()` in application code. It returns a lazy paginated result:
 
 ```typescript
 import { createNeonClient } from "@neon/sdk";
@@ -386,11 +387,27 @@ console.log(page.data.items);
 console.log(page.data.cursor); // pass to query.page(cursor) for the next page
 ```
 
-Use `source` to select `function` or `storage` records. Other structured filters include `service_name`, `scope_name`, severity, message content, and trace ID. `neon.logs.fields(projectId, branchId)` discovers observed fields. `neon.logs.fieldValues(projectId, branchId, fieldName, query?)` discovers values and reports whether the result was truncated. For selections the structured filters cannot express, `neon.logs.query()` accepts `logql`; do not combine it with structured content filters.
+`limit` applies to each page. Use `for await (const record of query)` to stream every page with errors thrown, or `query.all()` to collect every page in a `{ data, error }` result.
+
+With default client settings, `neon.logs.fields(projectId, branchId)` returns `{ data: string[], error }`. `neon.logs.fieldValues(projectId, branchId, fieldName, query?)` returns `{ data: { values, is_truncated }, error }`. When `is_truncated` is true, narrow `since` or `source` before using the values as filters.
+
+Use `source` to select `function` or `storage` records. The SDK type also accepts `pg_endpoint`, but that source has not been observed emitting records. Other structured filters include `service_name`, `scope_name`, `severity_text`, `minimum_severity`, `body_contains`, and `trace_id`. Some backends reject `minimum_severity`; use `severity_text` when that happens.
+
+The time window defaults to one hour and cannot exceed seven days. Supply either `since` or `start_time`, not both. A raw `logql` expression replaces the structured content filters, but `limit`, `sort_order`, and the time window still apply.
+
+The SDK and Loki-compatible HTTP API name the same selections differently:
+
+| `@neon/sdk` | Loki-compatible HTTP |
+| --- | --- |
+| `source: "function"` | `entity_type="function"` label |
+| `service_name`, `scope_name`, `trace_id`, `severity_text` | Same-named labels |
+| `minimum_severity` | `severity_text=~` regex covering that level and above |
+| `body_contains` | `\|=` line filter |
+| `sort_order: "asc"` / `"desc"` | `direction=forward` / `backward` |
 
 ### Query the Loki-compatible HTTP API
 
-Use the direct HTTP surface when you need LogQL or a raw Loki response:
+Use the direct HTTP surface for non-TypeScript clients or when a raw Loki response is required:
 
 ```bash
 curl --get \
@@ -402,7 +419,7 @@ curl --get \
   --data-urlencode 'direction=backward'
 ```
 
-The response uses the Loki `streams` envelope. This API accepts stream selectors and line filters, not aggregations, parsers, or formatting stages. Use `/labels` to list stream labels and `/label/{name}/values` to list values for one label. This HTTP surface is separate from the public Neon OpenAPI specification.
+The response uses the Loki `streams` envelope. Errors use `{ "status": "error", "error": "..." }`. A query needs at least one stream-label matcher. This API accepts stream selectors and line filters, not aggregations, parsers, or formatting stages. Use `/labels` to list stream labels and `/label/{name}/values` to list values for one label. This HTTP surface is separate from the public Neon OpenAPI specification.
 
 ## Manage Neon Resources
 

--- a/plugins/neon-postgres/skills/neon/SKILL.md
+++ b/plugins/neon-postgres/skills/neon/SKILL.md
@@ -360,7 +360,7 @@ For reading env you _already_ have on disk (typed and validated against your `ne
 
 ## Observability
 
-Neon exposes branch-scoped logs. **Today they cover Neon Functions and Object Storage only.** Postgres computes and the AI Gateway are coming; until then, neither emits records. Logs require beta enrollment and a project in `us-east-2`; an unavailable branch returns `404` with reason `telemetry_not_enabled`.
+Neon exposes branch-scoped logs. **Today they cover Neon Functions and Object Storage only.** Postgres computes and the AI Gateway are coming; until then, neither emits records. Logs are region-gated like the other services above — only `us-east-2` is enabled today, and a branch in any other region answers `404` with reason `telemetry_not_enabled` rather than an empty result.
 
 Use Neon CLI 3.1 or newer first. **Decide which branch you are querying.** Without `--branch`, the CLI uses the branch pinned in `.neon`, or the project's default branch when the workspace isn't linked. A deployed function or bucket usually lives on a different branch than the one checked out for development, so an empty result is more often the wrong branch than a missing log.
 

--- a/plugins/neon-postgres/skills/neon/SKILL.md
+++ b/plugins/neon-postgres/skills/neon/SKILL.md
@@ -361,7 +361,7 @@ For reading env you _already_ have on disk (typed and validated against your `ne
 
 Neon exposes branch-scoped logs from Functions, Object Storage, and Postgres computes. Logs require beta enrollment and a project in `us-east-2`; an unavailable branch returns `404` with reason `telemetry_not_enabled`.
 
-Use the CLI first:
+Use Neon CLI 3.1 or newer first:
 
 ```bash
 neon logs query --since 1h
@@ -370,9 +370,9 @@ neon logs fields
 neon logs field-values service_name --since 1h
 ```
 
-`--source` accepts `function`, `storage`, or `pg_endpoint`. Use `--logql` for a raw stream selector or line filter; run `neon logs --help` for the full filter and pagination interface.
+`--source` accepts `function`, `storage`, or `pg_endpoint`. Use `--logql` instead of the structured filters for a raw stream selector or line filter; run `neon logs --help` for the full filter and pagination interface.
 
-If the CLI is unavailable, fall back to the Neon MCP server's read-only `query_logs`, `list_log_fields`, and `list_log_field_values` tools. In TypeScript applications, use `@neon/sdk`: `neon.logs.query()`, `neon.logs.fields()`, and `neon.logs.fieldValues()`.
+If the CLI is unavailable, fall back to the Neon MCP server's read-only `query_logs`, `list_log_fields`, and `list_log_field_values` tools. In TypeScript applications, use `@neon/sdk`: `neon.logs.query`, `neon.logs.fields`, and `neon.logs.fieldValues`.
 
 ### Loki-compatible read API
 

--- a/plugins/neon-postgres/skills/neon/SKILL.md
+++ b/plugins/neon-postgres/skills/neon/SKILL.md
@@ -362,7 +362,7 @@ For reading env you _already_ have on disk (typed and validated against your `ne
 
 Neon exposes branch-scoped logs. **Today they cover Neon Functions and Object Storage only.** Postgres computes and the AI Gateway are coming; until then, neither emits records. Logs require beta enrollment and a project in `us-east-2`; an unavailable branch returns `404` with reason `telemetry_not_enabled`.
 
-Use Neon CLI 3.1 or newer first:
+Use Neon CLI 3.1 or newer first. **Decide which branch you are querying.** Without `--branch`, the CLI uses the branch pinned in `.neon`, or the project's default branch when the workspace isn't linked. A deployed function or bucket usually lives on a different branch than the one checked out for development, so an empty result is more often the wrong branch than a missing log.
 
 ```bash
 neon logs query --since 1h
@@ -372,9 +372,7 @@ neon logs fields
 neon logs field-values service_name --since 1h
 ```
 
-**Decide which branch you are querying.** Without `--branch`, the CLI uses the branch pinned in `.neon`, or the project's default branch when the workspace isn't linked. A deployed function or bucket usually lives on a different branch than the one checked out for development, so an empty result is more often the wrong branch than a missing log.
-
-`--source` accepts `function`, `storage`, and `pg_endpoint`, but only `function` and `storage` return records today — `pg_endpoint` is accepted and comes back empty until Postgres logs ship. The window defaults to 1h and cannot exceed 7d. If Neon reports `--minimum-severity` as unsupported on a branch, use `--severity-text` instead. Run `neon logs --help` for the full filter and pagination interface.
+`--source` accepts `function`, `storage`, and `pg_endpoint`, but only `function` and `storage` return records today — `pg_endpoint` is accepted and comes back empty until Postgres logs ship. The window defaults to 1h on `query` and 6h on `field-values`, and cannot exceed 7d on either. If Neon reports `--minimum-severity` as unsupported on a branch, use `--severity-text` instead. Run `neon logs --help` for the full filter and pagination interface.
 
 `--logql` replaces the structured filters with a raw stream selector or line filter. Its stream label is `entity_type`, not `source`:
 
@@ -394,13 +392,15 @@ for await (const record of neon.logs.query(projectId, branchId, {
   console.log(record.timestamp, record.severity_text, record.message);
 }
 
-const fields = await neon.logs.fields(projectId, branchId);
-const services = await neon.logs.fieldValues(projectId, branchId, "service_name");
+const { data: fields } = await neon.logs.fields(projectId, branchId);
+const { data: serviceNames } = await neon.logs.fieldValues(projectId, branchId, "service_name");
 ```
+
+`query`'s iterator always throws on error, but `fields` and `fieldValues` follow the client's `throwOnError`, which defaults to `false` and hands back `{ data, error }`. `fieldValues` resolves to the whole response, not a bare array: read `serviceNames.values`, and treat them as an arbitrary subset whenever `serviceNames.is_truncated` is true.
 
 ### Loki-compatible read API
 
-For Loki export or integration, authenticate with `Authorization: Bearer <NEON_API_KEY>` and use this branch-scoped base URL:
+For direct HTTP reads, authenticate with `Authorization: Bearer <NEON_API_KEY>` and use this branch-scoped base URL:
 
 ```text
 https://console.neon.tech/telemetry/v1/projects/{projectId}/branches/{branchId}/loki
@@ -413,6 +413,8 @@ The available endpoints are:
 - `GET /api/v1/label/{name}/values`
 
 This is a read-only Loki-compatible subset, not a push endpoint or complete Loki deployment. `query_range` supports LogQL stream selectors and line filters, plus `since` or `start`/`end`, `limit`, and `direction`; it does not support aggregations, parsers, or formatting stages.
+
+The paths above are the ones to call directly. A Loki client that builds its own paths — a Grafana data source appends `/loki/api/v1` to whatever URL it is given — may need a different root, so confirm the data-source URL against the Neon docs rather than pasting this base.
 
 ## Manage Neon Resources
 

--- a/plugins/neon-postgres/skills/neon/SKILL.md
+++ b/plugins/neon-postgres/skills/neon/SKILL.md
@@ -7,8 +7,9 @@ description: >-
   up the CLI or MCP server, and follow the branch-first workflow. Use when "Neon"
   or "Lakebase Postgres" is mentioned, or when any of its individual capabilities
   are the trigger: "object storage" or "S3", "buckets", "serverless functions",
-  "AI gateway", "call an LLM", "branch logs", "query logs", "observability",
-  "telemetry", "postgres", "database", or "backend".
+  "AI gateway", "call an LLM", "logs", "branch logs", "query logs",
+  "log export", "Loki", "Grafana", "observability", "telemetry", "postgres",
+  "database", or "backend".
 ---
 
 # Neon
@@ -365,15 +366,37 @@ Use Neon CLI 3.1 or newer first:
 
 ```bash
 neon logs query --since 1h
-neon logs query --source function --since 1h
-neon logs query --source storage --since 1h
+neon logs query --branch production --source function --minimum-severity error --since 6h
+neon logs query --source storage --since 1h --output json
 neon logs fields
 neon logs field-values service_name --since 1h
 ```
 
-`--source` accepts `function`, `storage`, and `pg_endpoint`, but only `function` and `storage` return records today — `pg_endpoint` is accepted and comes back empty until Postgres logs ship. Use `--logql` instead of the structured filters for a raw stream selector or line filter; run `neon logs --help` for the full filter and pagination interface.
+**Decide which branch you are querying.** Without `--branch`, the CLI uses the branch pinned in `.neon`, or the project's default branch when the workspace isn't linked. A deployed function or bucket usually lives on a different branch than the one checked out for development, so an empty result is more often the wrong branch than a missing log.
 
-If the CLI is unavailable, fall back to the Neon MCP server's read-only `query_logs`, `list_log_fields`, and `list_log_field_values` tools. In TypeScript applications, use `@neon/sdk`: `neon.logs.query`, `neon.logs.fields`, and `neon.logs.fieldValues`.
+`--source` accepts `function`, `storage`, and `pg_endpoint`, but only `function` and `storage` return records today — `pg_endpoint` is accepted and comes back empty until Postgres logs ship. The window defaults to 1h and cannot exceed 7d. If Neon reports `--minimum-severity` as unsupported on a branch, use `--severity-text` instead. Run `neon logs --help` for the full filter and pagination interface.
+
+`--logql` replaces the structured filters with a raw stream selector or line filter. Its stream label is `entity_type`, not `source`:
+
+```bash
+neon logs query --since 1h --logql '{entity_type="function"} |= "timeout"'
+```
+
+If the CLI is unavailable, fall back to the Neon MCP server's read-only `query_logs`, `list_log_fields`, and `list_log_field_values` tools.
+
+In TypeScript applications, use `@neon/sdk`. Project and branch are positional, and `query` returns a lazy paginated iterable rather than a promise:
+
+```typescript
+for await (const record of neon.logs.query(projectId, branchId, {
+  since: "1h",
+  source: "function",
+})) {
+  console.log(record.timestamp, record.severity_text, record.message);
+}
+
+const fields = await neon.logs.fields(projectId, branchId);
+const services = await neon.logs.fieldValues(projectId, branchId, "service_name");
+```
 
 ### Loki-compatible read API
 

--- a/skills/neon-functions/SKILL.md
+++ b/skills/neon-functions/SKILL.md
@@ -508,65 +508,11 @@ Because the function's URL is public, **authenticate before connecting the trans
 
 ### Built-in branch logs
 
-Neon exposes function logs through branch-scoped APIs. Logs currently require a project enrolled in the beta and located in `us-east-2`. The `@neon/sdk` API returns `404` with `reason: "telemetry_not_enabled"` when a branch cannot serve logs.
-
-When the Neon MCP server is available, use its read-only `query_logs`, `list_log_fields`, and `list_log_field_values` tools for interactive agent work. Use the typed `@neon/sdk` interface in application code. Keep queries bounded by a time window and page size:
-
-```typescript
-import { createNeonClient } from "@neon/sdk";
-
-const neon = createNeonClient({ apiKey: process.env.NEON_API_KEY! });
-const query = neon.logs.query(
-  process.env.NEON_PROJECT_ID!,
-  process.env.NEON_BRANCH_ID!,
-  {
-    source: "function",
-    since: "1h",
-    limit: 100,
-    sort_order: "desc",
-  },
-);
-
-const page = await query.page();
-if (page.error) throw page.error;
-
-console.log(page.data.items);
-console.log(page.data.cursor); // pass to query.page(cursor) for the next page
-```
-
-`limit` applies to each page. Use `for await (const record of query)` to stream every page with errors thrown, or `query.all()` to collect every page in a `{ data, error }` result.
-
-With default client settings, `neon.logs.fields(projectId, branchId)` returns `{ data: string[], error }`. `neon.logs.fieldValues(projectId, branchId, fieldName, query?)` returns `{ data: { values, is_truncated }, error }`. When `is_truncated` is true, narrow `since` or `source` before using the values as filters.
-
-An SDK query's time window defaults to one hour and cannot exceed seven days. Supply either `since` or `start_time`, not both. A raw `logql` expression replaces the structured content filters (`source`, service and scope names, severity, message content, and trace ID), but `limit`, `sort_order`, and the time window still apply. Some backends reject `minimum_severity`. `severity_text` is the fallback, but it is a case-sensitive exact match for one stored level, typically uppercase such as `ERROR`; it does not include higher levels.
-
-The SDK and Loki-compatible HTTP API name the same selections differently:
-
-| `@neon/sdk` | Loki-compatible HTTP |
-| --- | --- |
-| `source: "function"` | `entity_type="function"` label |
-| `service_name`, `scope_name`, `trace_id`, `severity_text` | Same-named labels |
-| `minimum_severity` | `severity_text=~` regex covering that level and above |
-| `sort_order: "asc"` / `"desc"` | `direction=forward` / `backward` |
-| `since`, `start_time`, `end_time` | `since`, `start`, `end` |
-
-The SDK's `body_contains` filter maps to Loki's `|=` line filter.
-
-Use the Loki-compatible HTTP API for non-TypeScript clients or when a raw Loki response is required:
-
 ```bash
-curl --get \
-  "https://console.neon.tech/telemetry/v1/projects/${NEON_PROJECT_ID}/branches/${NEON_BRANCH_ID}/loki/api/v1/query_range" \
-  --header "Authorization: Bearer ${NEON_API_KEY}" \
-  --data-urlencode 'query={entity_type="function"}' \
-  --data-urlencode 'since=1h' \
-  --data-urlencode 'limit=100' \
-  --data-urlencode 'direction=backward'
+neon logs query --source function --since 1h
 ```
 
-This endpoint returns the Loki `streams` response envelope. Errors use `{ "status": "error", "error": "..." }`. A query needs at least one stream-label matcher. The API accepts stream selectors and line filters, not aggregations, parsers, or formatting stages. Its `since` parameter uses Go durations such as `1h`; `start` and `end` accept RFC3339 timestamps or Unix nanoseconds.
-
-The HTTP interface has no cursor pagination. `limit` caps one response, and a non-empty `warnings` array means records were dropped. Narrow the time window or filters and query again. Use `/labels` to list stream labels and `/label/{name}/values` to list values for one label. This HTTP surface is separate from the public Neon OpenAPI specification.
+Use the CLI first. For field discovery, MCP fallback, `@neon/sdk`, Loki-compatible integration endpoints, and availability, see the parent `neon` skill's **Observability** section.
 
 ### Application instrumentation
 

--- a/skills/neon-functions/SKILL.md
+++ b/skills/neon-functions/SKILL.md
@@ -11,7 +11,8 @@ description: >-
   function", "deploy an API", "long-running function", "streaming agent",
   "SSE server", "WebSocket server", "webhook handler", "MCP server",
   "run code next to my database", "function that won't time out",
-  "Neon Functions", and "Neon Compute".
+  "function logs", "query logs", "observability", "Neon Functions", and
+  "Neon Compute".
 metadata:
   parent: neon
 ---
@@ -503,13 +504,13 @@ app.all("/mcp", async (c) => {
 
 Because the function's URL is public, **authenticate before connecting the transport** — [Better Auth](https://better-auth.com) covers both OAuth (its MCP plugin makes your app the authorization server so third-party clients self-authorize per the MCP spec) and a simpler API-key / session-JWT check for your own callers. [references/mcp.md](https://neon.com/docs/ai/skills/neon-functions/references/mcp.md) has the full pattern — server with Postgres-backed tools via Drizzle, both Better Auth auth options, and testing with `mcporter` / `add-mcp`.
 
-## Observability
+## Integrations and Observability
 
 ### Built-in branch logs
 
-Neon exposes function logs through branch-scoped APIs. Logs currently require a project enrolled in the beta and located in `us-east-2`; other branches can return `404` with `reason: "telemetry_not_enabled"`.
+Neon exposes function logs through branch-scoped APIs. Logs currently require a project enrolled in the beta and located in `us-east-2`. The `@neon/sdk` API returns `404` with `reason: "telemetry_not_enabled"` when a branch cannot serve logs.
 
-Use the typed `@neon/sdk` interface for application code and agents. Keep queries bounded by a time window and page size:
+When the Neon MCP server is available, use its read-only `query_logs`, `list_log_fields`, and `list_log_field_values` tools for interactive agent work. Use the typed `@neon/sdk` interface in application code. Keep queries bounded by a time window and page size:
 
 ```typescript
 import { createNeonClient } from "@neon/sdk";
@@ -533,9 +534,23 @@ console.log(page.data.items);
 console.log(page.data.cursor); // pass to query.page(cursor) for the next page
 ```
 
-`neon.logs.fields(projectId, branchId)` lists fields observed on the branch. `neon.logs.fieldValues(projectId, branchId, fieldName, query?)` lists values for one of those fields and returns `is_truncated` with the values. `neon.logs.query()` also accepts a raw `logql` expression when the structured filters cannot express a query. Do not combine `logql` with structured content filters.
+`limit` applies to each page. Use `for await (const record of query)` to stream every page with errors thrown, or `query.all()` to collect every page in a `{ data, error }` result.
 
-The same logs are available through a Loki-compatible HTTP API for direct LogQL access:
+With default client settings, `neon.logs.fields(projectId, branchId)` returns `{ data: string[], error }`. `neon.logs.fieldValues(projectId, branchId, fieldName, query?)` returns `{ data: { values, is_truncated }, error }`. When `is_truncated` is true, narrow `since` or `source` before using the values as filters.
+
+The time window defaults to one hour and cannot exceed seven days. Supply either `since` or `start_time`, not both. A raw `logql` expression replaces the structured content filters (`source`, service and scope names, severity, message content, and trace ID), but `limit`, `sort_order`, and the time window still apply. Some backends reject `minimum_severity`; use `severity_text` when that happens.
+
+The SDK and Loki-compatible HTTP API name the same selections differently:
+
+| `@neon/sdk` | Loki-compatible HTTP |
+| --- | --- |
+| `source: "function"` | `entity_type="function"` label |
+| `service_name`, `scope_name`, `trace_id`, `severity_text` | Same-named labels |
+| `minimum_severity` | `severity_text=~` regex covering that level and above |
+| `body_contains` | `\|=` line filter |
+| `sort_order: "asc"` / `"desc"` | `direction=forward` / `backward` |
+
+Use the Loki-compatible HTTP API for non-TypeScript clients or when a raw Loki response is required:
 
 ```bash
 curl --get \
@@ -547,7 +562,7 @@ curl --get \
   --data-urlencode 'direction=backward'
 ```
 
-This endpoint returns the Loki `streams` response envelope. It accepts stream selectors and line filters, not aggregations, parsers, or formatting stages. Use `/labels` to list stream labels and `/label/{name}/values` to list values for one label. This HTTP surface is separate from the public Neon OpenAPI specification.
+This endpoint returns the Loki `streams` response envelope. Errors use `{ "status": "error", "error": "..." }`. A query needs at least one stream-label matcher. The API accepts stream selectors and line filters, not aggregations, parsers, or formatting stages. Use `/labels` to list stream labels and `/label/{name}/values` to list values for one label. This HTTP surface is separate from the public Neon OpenAPI specification.
 
 ### Application instrumentation
 

--- a/skills/neon-functions/SKILL.md
+++ b/skills/neon-functions/SKILL.md
@@ -503,7 +503,53 @@ app.all("/mcp", async (c) => {
 
 Because the function's URL is public, **authenticate before connecting the transport** — [Better Auth](https://better-auth.com) covers both OAuth (its MCP plugin makes your app the authorization server so third-party clients self-authorize per the MCP spec) and a simpler API-key / session-JWT check for your own callers. [references/mcp.md](https://neon.com/docs/ai/skills/neon-functions/references/mcp.md) has the full pattern — server with Postgres-backed tools via Drizzle, both Better Auth auth options, and testing with `mcporter` / `add-mcp`.
 
-## Integrations and Observability
+## Observability
+
+### Built-in branch logs
+
+Neon exposes function logs through branch-scoped APIs. Logs are a beta feature and currently work only for projects in `us-east-2`.
+
+Use the typed `@neon/sdk` interface for application code and agents. Keep queries bounded by a time window and page size:
+
+```typescript
+import { createNeonClient } from "@neon/sdk";
+
+const neon = createNeonClient({ apiKey: process.env.NEON_API_KEY! });
+const query = neon.logs.query(
+  process.env.NEON_PROJECT_ID!,
+  process.env.NEON_BRANCH_ID!,
+  {
+    source: "function",
+    since: "1h",
+    limit: 100,
+    sort_order: "desc",
+  },
+);
+
+const page = await query.page();
+if (page.error) throw page.error;
+
+console.log(page.data.items);
+console.log(page.data.cursor); // pass to query.page(cursor) for the next page
+```
+
+`neon.logs.fields(projectId, branchId)` lists fields observed on the branch. `neon.logs.fieldValues(projectId, branchId, fieldName, query?)` lists values for one of those fields and returns `is_truncated` with the values. `neon.logs.query()` also accepts a raw `logql` expression when the structured filters cannot express a query. Do not combine `logql` with structured content filters.
+
+The same logs are available through a Loki-compatible HTTP API for direct LogQL access:
+
+```bash
+curl --get \
+  "https://console.neon.tech/telemetry/v1/projects/${NEON_PROJECT_ID}/branches/${NEON_BRANCH_ID}/loki/api/v1/query_range" \
+  --header "Authorization: Bearer ${NEON_API_KEY}" \
+  --data-urlencode 'query={entity_type="function"}' \
+  --data-urlencode 'since=1h' \
+  --data-urlencode 'limit=100' \
+  --data-urlencode 'direction=backward'
+```
+
+This endpoint returns the Loki `streams` response envelope. It accepts stream selectors and line filters, not aggregations, parsers, or formatting stages. Use `/labels` to list stream labels and `/label/{name}/values` to list values for one label. This HTTP surface is separate from the public Neon OpenAPI specification.
+
+### Application instrumentation
 
 A function is a long-lived Node.js process running a web-standard request/response handler, so standard Node integration SDKs work unchanged. Initialize them once at module load, gated on an env var so local dev and unconfigured branches stay a no-op, and pass secrets via `--env` or `neon.ts` `env`.
 

--- a/skills/neon-functions/SKILL.md
+++ b/skills/neon-functions/SKILL.md
@@ -507,7 +507,7 @@ Because the function's URL is public, **authenticate before connecting the trans
 
 ### Built-in branch logs
 
-Neon exposes function logs through branch-scoped APIs. Logs are a beta feature and currently work only for projects in `us-east-2`.
+Neon exposes function logs through branch-scoped APIs. Logs currently require a project enrolled in the beta and located in `us-east-2`; other branches can return `404` with `reason: "telemetry_not_enabled"`.
 
 Use the typed `@neon/sdk` interface for application code and agents. Keep queries bounded by a time window and page size:
 

--- a/skills/neon-functions/SKILL.md
+++ b/skills/neon-functions/SKILL.md
@@ -538,7 +538,7 @@ console.log(page.data.cursor); // pass to query.page(cursor) for the next page
 
 With default client settings, `neon.logs.fields(projectId, branchId)` returns `{ data: string[], error }`. `neon.logs.fieldValues(projectId, branchId, fieldName, query?)` returns `{ data: { values, is_truncated }, error }`. When `is_truncated` is true, narrow `since` or `source` before using the values as filters.
 
-The time window defaults to one hour and cannot exceed seven days. Supply either `since` or `start_time`, not both. A raw `logql` expression replaces the structured content filters (`source`, service and scope names, severity, message content, and trace ID), but `limit`, `sort_order`, and the time window still apply. Some backends reject `minimum_severity`; use `severity_text` when that happens.
+An SDK query's time window defaults to one hour and cannot exceed seven days. Supply either `since` or `start_time`, not both. A raw `logql` expression replaces the structured content filters (`source`, service and scope names, severity, message content, and trace ID), but `limit`, `sort_order`, and the time window still apply. Some backends reject `minimum_severity`. `severity_text` is the fallback, but it is a case-sensitive exact match for one stored level, typically uppercase such as `ERROR`; it does not include higher levels.
 
 The SDK and Loki-compatible HTTP API name the same selections differently:
 
@@ -547,8 +547,10 @@ The SDK and Loki-compatible HTTP API name the same selections differently:
 | `source: "function"` | `entity_type="function"` label |
 | `service_name`, `scope_name`, `trace_id`, `severity_text` | Same-named labels |
 | `minimum_severity` | `severity_text=~` regex covering that level and above |
-| `body_contains` | `\|=` line filter |
 | `sort_order: "asc"` / `"desc"` | `direction=forward` / `backward` |
+| `since`, `start_time`, `end_time` | `since`, `start`, `end` |
+
+The SDK's `body_contains` filter maps to Loki's `|=` line filter.
 
 Use the Loki-compatible HTTP API for non-TypeScript clients or when a raw Loki response is required:
 
@@ -562,7 +564,9 @@ curl --get \
   --data-urlencode 'direction=backward'
 ```
 
-This endpoint returns the Loki `streams` response envelope. Errors use `{ "status": "error", "error": "..." }`. A query needs at least one stream-label matcher. The API accepts stream selectors and line filters, not aggregations, parsers, or formatting stages. Use `/labels` to list stream labels and `/label/{name}/values` to list values for one label. This HTTP surface is separate from the public Neon OpenAPI specification.
+This endpoint returns the Loki `streams` response envelope. Errors use `{ "status": "error", "error": "..." }`. A query needs at least one stream-label matcher. The API accepts stream selectors and line filters, not aggregations, parsers, or formatting stages. Its `since` parameter uses Go durations such as `1h`; `start` and `end` accept RFC3339 timestamps or Unix nanoseconds.
+
+The HTTP interface has no cursor pagination. `limit` caps one response, and a non-empty `warnings` array means records were dropped. Narrow the time window or filters and query again. Use `/labels` to list stream labels and `/label/{name}/values` to list values for one label. This HTTP surface is separate from the public Neon OpenAPI specification.
 
 ### Application instrumentation
 

--- a/skills/neon-functions/SKILL.md
+++ b/skills/neon-functions/SKILL.md
@@ -508,10 +508,10 @@ Because the function's URL is public, **authenticate before connecting the trans
 ### Built-in branch logs
 
 ```bash
-neon logs query --source function --since 1h
+neon logs query --branch production --source function --since 1h
 ```
 
-Use the CLI first. For the required CLI version, field discovery, MCP fallback, `@neon/sdk`, Loki-compatible integration endpoints, and availability, see the parent `neon` skill's **Observability** section.
+Functions is one of the two sources branch logs cover today, alongside Object Storage. Logs are scoped to a single branch, so pass `--branch` when the deployed function isn't on the branch you're checked out on. Everything else about logs — the required CLI version, filters, the SDK, and Loki export — is in the parent `neon` skill's **Observability** section.
 
 ### Application instrumentation
 

--- a/skills/neon-functions/SKILL.md
+++ b/skills/neon-functions/SKILL.md
@@ -511,7 +511,7 @@ Because the function's URL is public, **authenticate before connecting the trans
 neon logs query --branch production --source function --since 1h
 ```
 
-Functions is one of the two sources branch logs cover today, alongside Object Storage. Logs are scoped to a single branch, so pass `--branch` when the deployed function isn't on the branch you're checked out on. Everything else about logs — the required CLI version, filters, the SDK, and Loki export — is in the parent `neon` skill's **Observability** section.
+Functions is one of the two sources branch logs cover today, alongside Object Storage. Logs are scoped to a single branch, so pass `--branch` when the deployed function isn't on the branch you're checked out on. Everything else about logs — the required CLI version, filters, the SDK, and the Loki-compatible read API — is in the parent `neon` skill's **Observability** section.
 
 ### Application instrumentation
 

--- a/skills/neon-functions/SKILL.md
+++ b/skills/neon-functions/SKILL.md
@@ -11,8 +11,7 @@ description: >-
   function", "deploy an API", "long-running function", "streaming agent",
   "SSE server", "WebSocket server", "webhook handler", "MCP server",
   "run code next to my database", "function that won't time out",
-  "function logs", "query logs", "observability", "Neon Functions", and
-  "Neon Compute".
+  "function logs", "Neon Functions", and "Neon Compute".
 metadata:
   parent: neon
 ---

--- a/skills/neon-functions/SKILL.md
+++ b/skills/neon-functions/SKILL.md
@@ -511,7 +511,7 @@ Because the function's URL is public, **authenticate before connecting the trans
 neon logs query --source function --since 1h
 ```
 
-Use the CLI first. For field discovery, MCP fallback, `@neon/sdk`, Loki-compatible integration endpoints, and availability, see the parent `neon` skill's **Observability** section.
+Use the CLI first. For the required CLI version, field discovery, MCP fallback, `@neon/sdk`, Loki-compatible integration endpoints, and availability, see the parent `neon` skill's **Observability** section.
 
 ### Application instrumentation
 

--- a/skills/neon-object-storage/SKILL.md
+++ b/skills/neon-object-storage/SKILL.md
@@ -202,7 +202,7 @@ The canonical pattern: an agent generates an image → `PutObject` into the `ima
 neon logs query --branch production --source storage --since 1h
 ```
 
-Storage is one of the two sources branch logs cover today, alongside Neon Functions. Logs are scoped to a single branch, so pass `--branch` when the bucket you're debugging isn't on the branch you're checked out on. Everything else about logs — the required CLI version, filters, the SDK, and Loki export — is in the parent `neon` skill's **Observability** section.
+Storage is one of the two sources branch logs cover today, alongside Neon Functions. Logs are scoped to a single branch, so pass `--branch` when the bucket you're debugging isn't on the branch you're checked out on. Everything else about logs — the required CLI version, filters, the SDK, and the Loki-compatible read API — is in the parent `neon` skill's **Observability** section.
 
 ## Neon Documentation
 

--- a/skills/neon-object-storage/SKILL.md
+++ b/skills/neon-object-storage/SKILL.md
@@ -9,8 +9,9 @@ description: >-
   want to add a separate storage provider like AWS S3, Cloudflare R2, or
   Supabase Storage. Triggers include "object storage", "bucket", "blob
   storage", "file storage", "store uploads/images/files", "S3-compatible
-  storage", "presigned URL", "where do I put files", "Neon Object Storage",
-  "Neon Storage", and "storage that branches with my database".
+  storage", "presigned URL", "where do I put files", "storage logs",
+  "Neon Object Storage", "Neon Storage", and "storage that branches with my
+  database".
 metadata:
   parent: neon
 ---
@@ -194,6 +195,14 @@ The canonical pattern: an agent generates an image → `PutObject` into the `ima
 ## CLI Bucket and Object Commands
 
 `neon` also has first-class bucket/object commands (`neon bucket create|list|delete`, `neon bucket object put|get|list|delete`) for scripting and one-off operations.
+
+## Built-in Branch Logs
+
+```bash
+neon logs query --source storage --since 1h
+```
+
+Storage is one of the two sources branch logs cover today, alongside Neon Functions. Use the CLI first. For the required CLI version, field discovery, MCP fallback, `@neon/sdk`, Loki-compatible integration endpoints, and availability, see the parent `neon` skill's **Observability** section.
 
 ## Neon Documentation
 

--- a/skills/neon-object-storage/SKILL.md
+++ b/skills/neon-object-storage/SKILL.md
@@ -10,8 +10,8 @@ description: >-
   Supabase Storage. Triggers include "object storage", "bucket", "blob
   storage", "file storage", "store uploads/images/files", "S3-compatible
   storage", "presigned URL", "where do I put files", "storage logs",
-  "Neon Object Storage", "Neon Storage", and "storage that branches with my
-  database".
+  "bucket logs", "Neon Object Storage", "Neon Storage", and "storage that
+  branches with my database".
 metadata:
   parent: neon
 ---
@@ -199,10 +199,10 @@ The canonical pattern: an agent generates an image → `PutObject` into the `ima
 ## Built-in Branch Logs
 
 ```bash
-neon logs query --source storage --since 1h
+neon logs query --branch production --source storage --since 1h
 ```
 
-Storage is one of the two sources branch logs cover today, alongside Neon Functions. Use the CLI first. For the required CLI version, field discovery, MCP fallback, `@neon/sdk`, Loki-compatible integration endpoints, and availability, see the parent `neon` skill's **Observability** section.
+Storage is one of the two sources branch logs cover today, alongside Neon Functions. Logs are scoped to a single branch, so pass `--branch` when the bucket you're debugging isn't on the branch you're checked out on. Everything else about logs — the required CLI version, filters, the SDK, and Loki export — is in the parent `neon` skill's **Observability** section.
 
 ## Neon Documentation
 

--- a/skills/neon/SKILL.md
+++ b/skills/neon/SKILL.md
@@ -360,7 +360,7 @@ For reading env you _already_ have on disk (typed and validated against your `ne
 
 ## Observability
 
-Neon exposes branch-scoped logs. **Today they cover Neon Functions and Object Storage only.** Postgres computes and the AI Gateway are coming; until then, neither emits records. Logs are region-gated like the other services above — only `us-east-2` is enabled today, and a branch in any other region answers `404` with reason `telemetry_not_enabled` rather than an empty result.
+Neon exposes branch-scoped logs. **Today they cover Neon Functions and Object Storage only.** Postgres computes and the AI Gateway are coming; until then, neither emits records. Logs are region-gated like the other beta services above — only `us-east-2` is enabled today, and a branch in any other region answers `404` with reason `telemetry_not_enabled` rather than an empty result.
 
 Use Neon CLI 3.1 or newer first. **Decide which branch you are querying.** Without `--branch`, the CLI uses the branch pinned in `.neon`, or the project's default branch when the workspace isn't linked. A deployed function or bucket usually lives on a different branch than the one checked out for development, so an empty result is more often the wrong branch than a missing log.
 

--- a/skills/neon/SKILL.md
+++ b/skills/neon/SKILL.md
@@ -359,18 +359,19 @@ For reading env you _already_ have on disk (typed and validated against your `ne
 
 ## Observability
 
-Neon exposes branch-scoped logs from Functions, Object Storage, and Postgres computes. Logs require beta enrollment and a project in `us-east-2`; an unavailable branch returns `404` with reason `telemetry_not_enabled`.
+Neon exposes branch-scoped logs. **Today they cover Neon Functions and Object Storage only.** Postgres computes and the AI Gateway are coming; until then, neither emits records. Logs require beta enrollment and a project in `us-east-2`; an unavailable branch returns `404` with reason `telemetry_not_enabled`.
 
 Use Neon CLI 3.1 or newer first:
 
 ```bash
 neon logs query --since 1h
 neon logs query --source function --since 1h
+neon logs query --source storage --since 1h
 neon logs fields
 neon logs field-values service_name --since 1h
 ```
 
-`--source` accepts `function`, `storage`, or `pg_endpoint`. Use `--logql` instead of the structured filters for a raw stream selector or line filter; run `neon logs --help` for the full filter and pagination interface.
+`--source` accepts `function`, `storage`, and `pg_endpoint`, but only `function` and `storage` return records today — `pg_endpoint` is accepted and comes back empty until Postgres logs ship. Use `--logql` instead of the structured filters for a raw stream selector or line filter; run `neon logs --help` for the full filter and pagination interface.
 
 If the CLI is unavailable, fall back to the Neon MCP server's read-only `query_logs`, `list_log_fields`, and `list_log_field_values` tools. In TypeScript applications, use `@neon/sdk`: `neon.logs.query`, `neon.logs.fields`, and `neon.logs.fieldValues`.
 

--- a/skills/neon/SKILL.md
+++ b/skills/neon/SKILL.md
@@ -358,7 +358,7 @@ For reading env you _already_ have on disk (typed and validated against your `ne
 
 ## Observability
 
-Neon exposes branch-scoped service logs through a typed SDK and a Loki-compatible HTTP API. Logs are a beta feature and currently work only for projects in `us-east-2`.
+Neon exposes branch-scoped service logs through a typed SDK and a Loki-compatible HTTP API. Logs currently require a project enrolled in the beta and located in `us-east-2`; other branches can return `404` with `reason: "telemetry_not_enabled"`.
 
 ### Query logs with `@neon/sdk`
 
@@ -386,7 +386,7 @@ console.log(page.data.items);
 console.log(page.data.cursor); // pass to query.page(cursor) for the next page
 ```
 
-Use `source` to select `function`, `storage`, or `pg_endpoint` records. Other structured filters include `service_name`, `scope_name`, severity, message content, and trace ID. `neon.logs.fields(projectId, branchId)` discovers observed fields. `neon.logs.fieldValues(projectId, branchId, fieldName, query?)` discovers values and reports whether the result was truncated. For selections the structured filters cannot express, `neon.logs.query()` accepts `logql`; do not combine it with structured content filters.
+Use `source` to select `function` or `storage` records. Other structured filters include `service_name`, `scope_name`, severity, message content, and trace ID. `neon.logs.fields(projectId, branchId)` discovers observed fields. `neon.logs.fieldValues(projectId, branchId, fieldName, query?)` discovers values and reports whether the result was truncated. For selections the structured filters cannot express, `neon.logs.query()` accepts `logql`; do not combine it with structured content filters.
 
 ### Query the Loki-compatible HTTP API
 

--- a/skills/neon/SKILL.md
+++ b/skills/neon/SKILL.md
@@ -359,73 +359,36 @@ For reading env you _already_ have on disk (typed and validated against your `ne
 
 ## Observability
 
-Neon exposes branch-scoped service logs through a typed SDK and a Loki-compatible HTTP API. Logs currently require a project enrolled in the beta and located in `us-east-2`. The `@neon/sdk` API returns `404` with `reason: "telemetry_not_enabled"` when a branch cannot serve logs.
+Neon exposes branch-scoped logs from Functions, Object Storage, and Postgres computes. Logs require beta enrollment and a project in `us-east-2`; an unavailable branch returns `404` with reason `telemetry_not_enabled`.
 
-When the Neon MCP server is available, use its read-only `query_logs`, `list_log_fields`, and `list_log_field_values` tools for interactive agent work.
-
-### Query logs with `@neon/sdk`
-
-Use `neon.logs.query()` in application code. It returns a lazy paginated result:
-
-```typescript
-import { createNeonClient } from "@neon/sdk";
-
-const neon = createNeonClient({ apiKey: process.env.NEON_API_KEY! });
-const query = neon.logs.query(
-  process.env.NEON_PROJECT_ID!,
-  process.env.NEON_BRANCH_ID!,
-  {
-    source: "function",
-    since: "1h",
-    limit: 100,
-    sort_order: "desc",
-  },
-);
-
-const page = await query.page();
-if (page.error) throw page.error;
-
-console.log(page.data.items);
-console.log(page.data.cursor); // pass to query.page(cursor) for the next page
-```
-
-`limit` applies to each page. Use `for await (const record of query)` to stream every page with errors thrown, or `query.all()` to collect every page in a `{ data, error }` result.
-
-With default client settings, `neon.logs.fields(projectId, branchId)` returns `{ data: string[], error }`. `neon.logs.fieldValues(projectId, branchId, fieldName, query?)` returns `{ data: { values, is_truncated }, error }`. When `is_truncated` is true, narrow `since` or `source` before using the values as filters.
-
-Use `source` to select `function` or `storage` records. The SDK type also accepts `pg_endpoint`, but that source has not been observed emitting records. Other structured filters include `service_name`, `scope_name`, `severity_text`, `minimum_severity`, `body_contains`, and `trace_id`. Some backends reject `minimum_severity`. `severity_text` is the fallback, but it is a case-sensitive exact match for one stored level, typically uppercase such as `ERROR`; it does not include higher levels.
-
-An SDK query's time window defaults to one hour and cannot exceed seven days. Supply either `since` or `start_time`, not both. A raw `logql` expression replaces the structured content filters, but `limit`, `sort_order`, and the time window still apply.
-
-The SDK and Loki-compatible HTTP API name the same selections differently:
-
-| `@neon/sdk` | Loki-compatible HTTP |
-| --- | --- |
-| `source: "function"` | `entity_type="function"` label |
-| `service_name`, `scope_name`, `trace_id`, `severity_text` | Same-named labels |
-| `minimum_severity` | `severity_text=~` regex covering that level and above |
-| `sort_order: "asc"` / `"desc"` | `direction=forward` / `backward` |
-| `since`, `start_time`, `end_time` | `since`, `start`, `end` |
-
-The SDK's `body_contains` filter maps to Loki's `|=` line filter.
-
-### Query the Loki-compatible HTTP API
-
-Use the direct HTTP surface for non-TypeScript clients or when a raw Loki response is required:
+Use the CLI first:
 
 ```bash
-curl --get \
-  "https://console.neon.tech/telemetry/v1/projects/${NEON_PROJECT_ID}/branches/${NEON_BRANCH_ID}/loki/api/v1/query_range" \
-  --header "Authorization: Bearer ${NEON_API_KEY}" \
-  --data-urlencode 'query={entity_type="function"}' \
-  --data-urlencode 'since=1h' \
-  --data-urlencode 'limit=100' \
-  --data-urlencode 'direction=backward'
+neon logs query --since 1h
+neon logs query --source function --since 1h
+neon logs fields
+neon logs field-values service_name --since 1h
 ```
 
-The response uses the Loki `streams` envelope. Errors use `{ "status": "error", "error": "..." }`. A query needs at least one stream-label matcher. This API accepts stream selectors and line filters, not aggregations, parsers, or formatting stages. Its `since` parameter uses Go durations such as `1h`; `start` and `end` accept RFC3339 timestamps or Unix nanoseconds.
+`--source` accepts `function`, `storage`, or `pg_endpoint`. Use `--logql` for a raw stream selector or line filter; run `neon logs --help` for the full filter and pagination interface.
 
-The HTTP interface has no cursor pagination. `limit` caps one response, and a non-empty `warnings` array means records were dropped. Narrow the time window or filters and query again. Use `/labels` to list stream labels and `/label/{name}/values` to list values for one label. This HTTP surface is separate from the public Neon OpenAPI specification.
+If the CLI is unavailable, fall back to the Neon MCP server's read-only `query_logs`, `list_log_fields`, and `list_log_field_values` tools. In TypeScript applications, use `@neon/sdk`: `neon.logs.query()`, `neon.logs.fields()`, and `neon.logs.fieldValues()`.
+
+### Loki-compatible read API
+
+For Loki export or integration, authenticate with `Authorization: Bearer <NEON_API_KEY>` and use this branch-scoped base URL:
+
+```text
+https://console.neon.tech/telemetry/v1/projects/{projectId}/branches/{branchId}/loki
+```
+
+The available endpoints are:
+
+- `GET /api/v1/query_range`
+- `GET /api/v1/labels`
+- `GET /api/v1/label/{name}/values`
+
+This is a read-only Loki-compatible subset, not a push endpoint or complete Loki deployment. `query_range` supports LogQL stream selectors and line filters, plus `since` or `start`/`end`, `limit`, and `direction`; it does not support aggregations, parsers, or formatting stages.
 
 ## Manage Neon Resources
 

--- a/skills/neon/SKILL.md
+++ b/skills/neon/SKILL.md
@@ -361,9 +361,11 @@ For reading env you _already_ have on disk (typed and validated against your `ne
 
 Neon exposes branch-scoped service logs through a typed SDK and a Loki-compatible HTTP API. Logs currently require a project enrolled in the beta and located in `us-east-2`. The `@neon/sdk` API returns `404` with `reason: "telemetry_not_enabled"` when a branch cannot serve logs.
 
+When the Neon MCP server is available, use its read-only `query_logs`, `list_log_fields`, and `list_log_field_values` tools for interactive agent work.
+
 ### Query logs with `@neon/sdk`
 
-When the Neon MCP server is available, use its read-only `query_logs`, `list_log_fields`, and `list_log_field_values` tools for interactive agent work. Use `neon.logs.query()` in application code. It returns a lazy paginated result:
+Use `neon.logs.query()` in application code. It returns a lazy paginated result:
 
 ```typescript
 import { createNeonClient } from "@neon/sdk";
@@ -391,9 +393,9 @@ console.log(page.data.cursor); // pass to query.page(cursor) for the next page
 
 With default client settings, `neon.logs.fields(projectId, branchId)` returns `{ data: string[], error }`. `neon.logs.fieldValues(projectId, branchId, fieldName, query?)` returns `{ data: { values, is_truncated }, error }`. When `is_truncated` is true, narrow `since` or `source` before using the values as filters.
 
-Use `source` to select `function` or `storage` records. The SDK type also accepts `pg_endpoint`, but that source has not been observed emitting records. Other structured filters include `service_name`, `scope_name`, `severity_text`, `minimum_severity`, `body_contains`, and `trace_id`. Some backends reject `minimum_severity`; use `severity_text` when that happens.
+Use `source` to select `function` or `storage` records. The SDK type also accepts `pg_endpoint`, but that source has not been observed emitting records. Other structured filters include `service_name`, `scope_name`, `severity_text`, `minimum_severity`, `body_contains`, and `trace_id`. Some backends reject `minimum_severity`. `severity_text` is the fallback, but it is a case-sensitive exact match for one stored level, typically uppercase such as `ERROR`; it does not include higher levels.
 
-The time window defaults to one hour and cannot exceed seven days. Supply either `since` or `start_time`, not both. A raw `logql` expression replaces the structured content filters, but `limit`, `sort_order`, and the time window still apply.
+An SDK query's time window defaults to one hour and cannot exceed seven days. Supply either `since` or `start_time`, not both. A raw `logql` expression replaces the structured content filters, but `limit`, `sort_order`, and the time window still apply.
 
 The SDK and Loki-compatible HTTP API name the same selections differently:
 
@@ -402,8 +404,10 @@ The SDK and Loki-compatible HTTP API name the same selections differently:
 | `source: "function"` | `entity_type="function"` label |
 | `service_name`, `scope_name`, `trace_id`, `severity_text` | Same-named labels |
 | `minimum_severity` | `severity_text=~` regex covering that level and above |
-| `body_contains` | `\|=` line filter |
 | `sort_order: "asc"` / `"desc"` | `direction=forward` / `backward` |
+| `since`, `start_time`, `end_time` | `since`, `start`, `end` |
+
+The SDK's `body_contains` filter maps to Loki's `|=` line filter.
 
 ### Query the Loki-compatible HTTP API
 
@@ -419,7 +423,9 @@ curl --get \
   --data-urlencode 'direction=backward'
 ```
 
-The response uses the Loki `streams` envelope. Errors use `{ "status": "error", "error": "..." }`. A query needs at least one stream-label matcher. This API accepts stream selectors and line filters, not aggregations, parsers, or formatting stages. Use `/labels` to list stream labels and `/label/{name}/values` to list values for one label. This HTTP surface is separate from the public Neon OpenAPI specification.
+The response uses the Loki `streams` envelope. Errors use `{ "status": "error", "error": "..." }`. A query needs at least one stream-label matcher. This API accepts stream selectors and line filters, not aggregations, parsers, or formatting stages. Its `since` parameter uses Go durations such as `1h`; `start` and `end` accept RFC3339 timestamps or Unix nanoseconds.
+
+The HTTP interface has no cursor pagination. `limit` caps one response, and a non-empty `warnings` array means records were dropped. Narrow the time window or filters and query again. Use `/labels` to list stream labels and `/label/{name}/values` to list values for one label. This HTTP surface is separate from the public Neon OpenAPI specification.
 
 ## Manage Neon Resources
 

--- a/skills/neon/SKILL.md
+++ b/skills/neon/SKILL.md
@@ -356,6 +356,54 @@ When an agent should not write a local `.env`, instruct it (for example in your 
 
 For reading env you _already_ have on disk (typed and validated against your `neon.ts`), use `parseEnv` — see [Type-safe env vars with parseEnv](#type-safe-env-vars-with-parseenv) above.
 
+## Observability
+
+Neon exposes branch-scoped service logs through a typed SDK and a Loki-compatible HTTP API. Logs are a beta feature and currently work only for projects in `us-east-2`.
+
+### Query logs with `@neon/sdk`
+
+Use `neon.logs.query()` for bounded log queries. It returns a lazy paginated result:
+
+```typescript
+import { createNeonClient } from "@neon/sdk";
+
+const neon = createNeonClient({ apiKey: process.env.NEON_API_KEY! });
+const query = neon.logs.query(
+  process.env.NEON_PROJECT_ID!,
+  process.env.NEON_BRANCH_ID!,
+  {
+    source: "function",
+    since: "1h",
+    limit: 100,
+    sort_order: "desc",
+  },
+);
+
+const page = await query.page();
+if (page.error) throw page.error;
+
+console.log(page.data.items);
+console.log(page.data.cursor); // pass to query.page(cursor) for the next page
+```
+
+Use `source` to select `function`, `storage`, or `pg_endpoint` records. Other structured filters include `service_name`, `scope_name`, severity, message content, and trace ID. `neon.logs.fields(projectId, branchId)` discovers observed fields. `neon.logs.fieldValues(projectId, branchId, fieldName, query?)` discovers values and reports whether the result was truncated. For selections the structured filters cannot express, `neon.logs.query()` accepts `logql`; do not combine it with structured content filters.
+
+### Query the Loki-compatible HTTP API
+
+Use the direct HTTP surface when you need LogQL or a raw Loki response:
+
+```bash
+curl --get \
+  "https://console.neon.tech/telemetry/v1/projects/${NEON_PROJECT_ID}/branches/${NEON_BRANCH_ID}/loki/api/v1/query_range" \
+  --header "Authorization: Bearer ${NEON_API_KEY}" \
+  --data-urlencode 'query={entity_type="function"}' \
+  --data-urlencode 'since=1h' \
+  --data-urlencode 'limit=100' \
+  --data-urlencode 'direction=backward'
+```
+
+The response uses the Loki `streams` envelope. This API accepts stream selectors and line filters, not aggregations, parsers, or formatting stages. Use `/labels` to list stream labels and `/label/{name}/values` to list values for one label. This HTTP surface is separate from the public Neon OpenAPI specification.
+
 ## Manage Neon Resources
 
 Recommended: Use `@neon/sdk` to manage Neon resources programmatically, such as creating projects, branches, and snapshots for dev scripts, CI/CD automations, and platforms building on top of Neon.

--- a/skills/neon/SKILL.md
+++ b/skills/neon/SKILL.md
@@ -7,7 +7,8 @@ description: >-
   up the CLI or MCP server, and follow the branch-first workflow. Use when "Neon"
   or "Lakebase Postgres" is mentioned, or when any of its individual capabilities
   are the trigger: "object storage" or "S3", "buckets", "serverless functions",
-  "AI gateway", "call an LLM", "postgres", "database", or "backend".
+  "AI gateway", "call an LLM", "branch logs", "query logs", "observability",
+  "telemetry", "postgres", "database", or "backend".
 ---
 
 # Neon
@@ -358,11 +359,11 @@ For reading env you _already_ have on disk (typed and validated against your `ne
 
 ## Observability
 
-Neon exposes branch-scoped service logs through a typed SDK and a Loki-compatible HTTP API. Logs currently require a project enrolled in the beta and located in `us-east-2`; other branches can return `404` with `reason: "telemetry_not_enabled"`.
+Neon exposes branch-scoped service logs through a typed SDK and a Loki-compatible HTTP API. Logs currently require a project enrolled in the beta and located in `us-east-2`. The `@neon/sdk` API returns `404` with `reason: "telemetry_not_enabled"` when a branch cannot serve logs.
 
 ### Query logs with `@neon/sdk`
 
-Use `neon.logs.query()` for bounded log queries. It returns a lazy paginated result:
+When the Neon MCP server is available, use its read-only `query_logs`, `list_log_fields`, and `list_log_field_values` tools for interactive agent work. Use `neon.logs.query()` in application code. It returns a lazy paginated result:
 
 ```typescript
 import { createNeonClient } from "@neon/sdk";
@@ -386,11 +387,27 @@ console.log(page.data.items);
 console.log(page.data.cursor); // pass to query.page(cursor) for the next page
 ```
 
-Use `source` to select `function` or `storage` records. Other structured filters include `service_name`, `scope_name`, severity, message content, and trace ID. `neon.logs.fields(projectId, branchId)` discovers observed fields. `neon.logs.fieldValues(projectId, branchId, fieldName, query?)` discovers values and reports whether the result was truncated. For selections the structured filters cannot express, `neon.logs.query()` accepts `logql`; do not combine it with structured content filters.
+`limit` applies to each page. Use `for await (const record of query)` to stream every page with errors thrown, or `query.all()` to collect every page in a `{ data, error }` result.
+
+With default client settings, `neon.logs.fields(projectId, branchId)` returns `{ data: string[], error }`. `neon.logs.fieldValues(projectId, branchId, fieldName, query?)` returns `{ data: { values, is_truncated }, error }`. When `is_truncated` is true, narrow `since` or `source` before using the values as filters.
+
+Use `source` to select `function` or `storage` records. The SDK type also accepts `pg_endpoint`, but that source has not been observed emitting records. Other structured filters include `service_name`, `scope_name`, `severity_text`, `minimum_severity`, `body_contains`, and `trace_id`. Some backends reject `minimum_severity`; use `severity_text` when that happens.
+
+The time window defaults to one hour and cannot exceed seven days. Supply either `since` or `start_time`, not both. A raw `logql` expression replaces the structured content filters, but `limit`, `sort_order`, and the time window still apply.
+
+The SDK and Loki-compatible HTTP API name the same selections differently:
+
+| `@neon/sdk` | Loki-compatible HTTP |
+| --- | --- |
+| `source: "function"` | `entity_type="function"` label |
+| `service_name`, `scope_name`, `trace_id`, `severity_text` | Same-named labels |
+| `minimum_severity` | `severity_text=~` regex covering that level and above |
+| `body_contains` | `\|=` line filter |
+| `sort_order: "asc"` / `"desc"` | `direction=forward` / `backward` |
 
 ### Query the Loki-compatible HTTP API
 
-Use the direct HTTP surface when you need LogQL or a raw Loki response:
+Use the direct HTTP surface for non-TypeScript clients or when a raw Loki response is required:
 
 ```bash
 curl --get \
@@ -402,7 +419,7 @@ curl --get \
   --data-urlencode 'direction=backward'
 ```
 
-The response uses the Loki `streams` envelope. This API accepts stream selectors and line filters, not aggregations, parsers, or formatting stages. Use `/labels` to list stream labels and `/label/{name}/values` to list values for one label. This HTTP surface is separate from the public Neon OpenAPI specification.
+The response uses the Loki `streams` envelope. Errors use `{ "status": "error", "error": "..." }`. A query needs at least one stream-label matcher. This API accepts stream selectors and line filters, not aggregations, parsers, or formatting stages. Use `/labels` to list stream labels and `/label/{name}/values` to list values for one label. This HTTP surface is separate from the public Neon OpenAPI specification.
 
 ## Manage Neon Resources
 

--- a/skills/neon/SKILL.md
+++ b/skills/neon/SKILL.md
@@ -360,7 +360,7 @@ For reading env you _already_ have on disk (typed and validated against your `ne
 
 ## Observability
 
-Neon exposes branch-scoped logs. **Today they cover Neon Functions and Object Storage only.** Postgres computes and the AI Gateway are coming; until then, neither emits records. Logs require beta enrollment and a project in `us-east-2`; an unavailable branch returns `404` with reason `telemetry_not_enabled`.
+Neon exposes branch-scoped logs. **Today they cover Neon Functions and Object Storage only.** Postgres computes and the AI Gateway are coming; until then, neither emits records. Logs are region-gated like the other services above — only `us-east-2` is enabled today, and a branch in any other region answers `404` with reason `telemetry_not_enabled` rather than an empty result.
 
 Use Neon CLI 3.1 or newer first. **Decide which branch you are querying.** Without `--branch`, the CLI uses the branch pinned in `.neon`, or the project's default branch when the workspace isn't linked. A deployed function or bucket usually lives on a different branch than the one checked out for development, so an empty result is more often the wrong branch than a missing log.
 

--- a/skills/neon/SKILL.md
+++ b/skills/neon/SKILL.md
@@ -361,7 +361,7 @@ For reading env you _already_ have on disk (typed and validated against your `ne
 
 Neon exposes branch-scoped logs from Functions, Object Storage, and Postgres computes. Logs require beta enrollment and a project in `us-east-2`; an unavailable branch returns `404` with reason `telemetry_not_enabled`.
 
-Use the CLI first:
+Use Neon CLI 3.1 or newer first:
 
 ```bash
 neon logs query --since 1h
@@ -370,9 +370,9 @@ neon logs fields
 neon logs field-values service_name --since 1h
 ```
 
-`--source` accepts `function`, `storage`, or `pg_endpoint`. Use `--logql` for a raw stream selector or line filter; run `neon logs --help` for the full filter and pagination interface.
+`--source` accepts `function`, `storage`, or `pg_endpoint`. Use `--logql` instead of the structured filters for a raw stream selector or line filter; run `neon logs --help` for the full filter and pagination interface.
 
-If the CLI is unavailable, fall back to the Neon MCP server's read-only `query_logs`, `list_log_fields`, and `list_log_field_values` tools. In TypeScript applications, use `@neon/sdk`: `neon.logs.query()`, `neon.logs.fields()`, and `neon.logs.fieldValues()`.
+If the CLI is unavailable, fall back to the Neon MCP server's read-only `query_logs`, `list_log_fields`, and `list_log_field_values` tools. In TypeScript applications, use `@neon/sdk`: `neon.logs.query`, `neon.logs.fields`, and `neon.logs.fieldValues`.
 
 ### Loki-compatible read API
 

--- a/skills/neon/SKILL.md
+++ b/skills/neon/SKILL.md
@@ -362,7 +362,7 @@ For reading env you _already_ have on disk (typed and validated against your `ne
 
 Neon exposes branch-scoped logs. **Today they cover Neon Functions and Object Storage only.** Postgres computes and the AI Gateway are coming; until then, neither emits records. Logs require beta enrollment and a project in `us-east-2`; an unavailable branch returns `404` with reason `telemetry_not_enabled`.
 
-Use Neon CLI 3.1 or newer first:
+Use Neon CLI 3.1 or newer first. **Decide which branch you are querying.** Without `--branch`, the CLI uses the branch pinned in `.neon`, or the project's default branch when the workspace isn't linked. A deployed function or bucket usually lives on a different branch than the one checked out for development, so an empty result is more often the wrong branch than a missing log.
 
 ```bash
 neon logs query --since 1h
@@ -372,9 +372,7 @@ neon logs fields
 neon logs field-values service_name --since 1h
 ```
 
-**Decide which branch you are querying.** Without `--branch`, the CLI uses the branch pinned in `.neon`, or the project's default branch when the workspace isn't linked. A deployed function or bucket usually lives on a different branch than the one checked out for development, so an empty result is more often the wrong branch than a missing log.
-
-`--source` accepts `function`, `storage`, and `pg_endpoint`, but only `function` and `storage` return records today — `pg_endpoint` is accepted and comes back empty until Postgres logs ship. The window defaults to 1h and cannot exceed 7d. If Neon reports `--minimum-severity` as unsupported on a branch, use `--severity-text` instead. Run `neon logs --help` for the full filter and pagination interface.
+`--source` accepts `function`, `storage`, and `pg_endpoint`, but only `function` and `storage` return records today — `pg_endpoint` is accepted and comes back empty until Postgres logs ship. The window defaults to 1h on `query` and 6h on `field-values`, and cannot exceed 7d on either. If Neon reports `--minimum-severity` as unsupported on a branch, use `--severity-text` instead. Run `neon logs --help` for the full filter and pagination interface.
 
 `--logql` replaces the structured filters with a raw stream selector or line filter. Its stream label is `entity_type`, not `source`:
 
@@ -394,13 +392,15 @@ for await (const record of neon.logs.query(projectId, branchId, {
   console.log(record.timestamp, record.severity_text, record.message);
 }
 
-const fields = await neon.logs.fields(projectId, branchId);
-const services = await neon.logs.fieldValues(projectId, branchId, "service_name");
+const { data: fields } = await neon.logs.fields(projectId, branchId);
+const { data: serviceNames } = await neon.logs.fieldValues(projectId, branchId, "service_name");
 ```
+
+`query`'s iterator always throws on error, but `fields` and `fieldValues` follow the client's `throwOnError`, which defaults to `false` and hands back `{ data, error }`. `fieldValues` resolves to the whole response, not a bare array: read `serviceNames.values`, and treat them as an arbitrary subset whenever `serviceNames.is_truncated` is true.
 
 ### Loki-compatible read API
 
-For Loki export or integration, authenticate with `Authorization: Bearer <NEON_API_KEY>` and use this branch-scoped base URL:
+For direct HTTP reads, authenticate with `Authorization: Bearer <NEON_API_KEY>` and use this branch-scoped base URL:
 
 ```text
 https://console.neon.tech/telemetry/v1/projects/{projectId}/branches/{branchId}/loki
@@ -413,6 +413,8 @@ The available endpoints are:
 - `GET /api/v1/label/{name}/values`
 
 This is a read-only Loki-compatible subset, not a push endpoint or complete Loki deployment. `query_range` supports LogQL stream selectors and line filters, plus `since` or `start`/`end`, `limit`, and `direction`; it does not support aggregations, parsers, or formatting stages.
+
+The paths above are the ones to call directly. A Loki client that builds its own paths — a Grafana data source appends `/loki/api/v1` to whatever URL it is given — may need a different root, so confirm the data-source URL against the Neon docs rather than pasting this base.
 
 ## Manage Neon Resources
 

--- a/skills/neon/SKILL.md
+++ b/skills/neon/SKILL.md
@@ -7,8 +7,9 @@ description: >-
   up the CLI or MCP server, and follow the branch-first workflow. Use when "Neon"
   or "Lakebase Postgres" is mentioned, or when any of its individual capabilities
   are the trigger: "object storage" or "S3", "buckets", "serverless functions",
-  "AI gateway", "call an LLM", "branch logs", "query logs", "observability",
-  "telemetry", "postgres", "database", or "backend".
+  "AI gateway", "call an LLM", "logs", "branch logs", "query logs",
+  "log export", "Loki", "Grafana", "observability", "telemetry", "postgres",
+  "database", or "backend".
 ---
 
 # Neon
@@ -365,15 +366,37 @@ Use Neon CLI 3.1 or newer first:
 
 ```bash
 neon logs query --since 1h
-neon logs query --source function --since 1h
-neon logs query --source storage --since 1h
+neon logs query --branch production --source function --minimum-severity error --since 6h
+neon logs query --source storage --since 1h --output json
 neon logs fields
 neon logs field-values service_name --since 1h
 ```
 
-`--source` accepts `function`, `storage`, and `pg_endpoint`, but only `function` and `storage` return records today — `pg_endpoint` is accepted and comes back empty until Postgres logs ship. Use `--logql` instead of the structured filters for a raw stream selector or line filter; run `neon logs --help` for the full filter and pagination interface.
+**Decide which branch you are querying.** Without `--branch`, the CLI uses the branch pinned in `.neon`, or the project's default branch when the workspace isn't linked. A deployed function or bucket usually lives on a different branch than the one checked out for development, so an empty result is more often the wrong branch than a missing log.
 
-If the CLI is unavailable, fall back to the Neon MCP server's read-only `query_logs`, `list_log_fields`, and `list_log_field_values` tools. In TypeScript applications, use `@neon/sdk`: `neon.logs.query`, `neon.logs.fields`, and `neon.logs.fieldValues`.
+`--source` accepts `function`, `storage`, and `pg_endpoint`, but only `function` and `storage` return records today — `pg_endpoint` is accepted and comes back empty until Postgres logs ship. The window defaults to 1h and cannot exceed 7d. If Neon reports `--minimum-severity` as unsupported on a branch, use `--severity-text` instead. Run `neon logs --help` for the full filter and pagination interface.
+
+`--logql` replaces the structured filters with a raw stream selector or line filter. Its stream label is `entity_type`, not `source`:
+
+```bash
+neon logs query --since 1h --logql '{entity_type="function"} |= "timeout"'
+```
+
+If the CLI is unavailable, fall back to the Neon MCP server's read-only `query_logs`, `list_log_fields`, and `list_log_field_values` tools.
+
+In TypeScript applications, use `@neon/sdk`. Project and branch are positional, and `query` returns a lazy paginated iterable rather than a promise:
+
+```typescript
+for await (const record of neon.logs.query(projectId, branchId, {
+  since: "1h",
+  source: "function",
+})) {
+  console.log(record.timestamp, record.severity_text, record.message);
+}
+
+const fields = await neon.logs.fields(projectId, branchId);
+const services = await neon.logs.fieldValues(projectId, branchId, "service_name");
+```
 
 ### Loki-compatible read API
 


### PR DESCRIPTION
## Problem

The Neon skills do not point agents to Neon's built-in branch logs. An agent asked "why is my function erroring" has nothing to go on, and every failure mode it would hit on its own is silent — each returns an empty result rather than an error:

- **Wrong branch.** Logs are scoped to one branch. Without `--branch`, the CLI uses the branch pinned in `.neon`, or the project's default branch. The skills teach a dev-branch workflow, so the branch an agent is checked out on is rarely the one a deployed function runs on.
- **A source that emits nothing.** `--source` accepts `pg_endpoint` because the API and SDK union accept it, but Postgres computes produce no records yet. The CLI's own help example advertises `--source pg_endpoint` as "Postgres compute errors on main."
- **The wrong LogQL label.** `--logql` selects on `entity_type`; `source` is a structured filter, not a stream label.

An agent that hits any of these reports "you have no logs" to a user whose logs exist.

## Solution

The shared interface lives in the `neon` overview under **Observability**. The two child skills that have logs today, `neon-functions` and `neon-object-storage`, carry a short source-specific section with their own trigger, a branch-aware command, and one line pointing back to the overview.

The overview recommends, in order: the Neon CLI 3.1 or newer, the Neon MCP read tools when the CLI is unavailable, `@neon/sdk` for TypeScript applications, and the Loki-compatible read API for direct HTTP reads. Each silent failure mode is stated next to the flag that causes it, and the branch caveat sits above the command block rather than below it. Generated Neon plugin copies are synced with the source skills.

## Coverage today

Branch logs carry **Neon Functions and Object Storage only**. Postgres computes and the AI Gateway are coming. The overview states this in the section's opening paragraph and again beside the `--source` values, so an agent cannot reach `pg_endpoint` without reading why it comes back empty.

## User-facing interface

Generic `logs`, `branch logs`, `query logs`, `log export`, `Loki`, `Grafana`, `observability`, and `telemetry` requests route to the `neon` overview. `function logs` also activates `neon-functions`; `storage logs` and `bucket logs` also activate `neon-object-storage`.

```bash
neon logs query --since 1h
neon logs query --branch production --source function --minimum-severity error --since 6h
neon logs query --source storage --since 1h --output json
neon logs query --since 1h --logql '{entity_type="function"} |= "timeout"'
neon logs fields
neon logs field-values service_name --since 1h
```

The window defaults to 1h on `query` and 6h on `field-values`, and cannot exceed 7d on either. If a branch reports `--minimum-severity` as unsupported, `--severity-text` still works.

MCP fallback: `query_logs`, `list_log_fields`, and `list_log_field_values`.

`@neon/sdk` takes project and branch as positionals. `query` returns a lazy paginated iterable rather than a promise, and its iterator always throws on error; `fields` and `fieldValues` follow the client's `throwOnError`, which defaults to `false`:

```typescript
for await (const record of neon.logs.query(projectId, branchId, {
  since: "1h",
  source: "function",
})) {
  console.log(record.timestamp, record.severity_text, record.message);
}

const { data: fields } = await neon.logs.fields(projectId, branchId);
const { data: serviceNames } = await neon.logs.fieldValues(projectId, branchId, "service_name");
```

`fieldValues` resolves to the whole response rather than a bare array, because `is_truncated` decides whether the values can be trusted.

```text
Base: https://console.neon.tech/telemetry/v1/projects/{projectId}/branches/{branchId}/loki

GET /api/v1/query_range
GET /api/v1/labels
GET /api/v1/label/{name}/values
```

Authenticate the Loki-compatible API with `Authorization: Bearer <NEON_API_KEY>`.

## Verification

- `npm run validate:ci`
- Generated plugin skills verified in sync with their sources.
- All three Loki-compatible routes returned `200` against a healthy beta branch.
- `--source` values checked against `LOG_SOURCES` in the CLI, which `satisfies` constrains to the SDK's `ProjectBranchLogSource` union.
- Branch resolution read from `branchIdFromProps`, which falls back to the project's default branch.
- Window defaults and the 7d ceiling read from the CLI's `windowOptions("1h")` on `query` and `windowOptions("6h")` on `field-values`; the `--severity-text` fallback and the `entity_type` LogQL example taken from the CLI's own flag descriptions and examples.
- SDK signatures and return shapes read from `packages/sdk/src/neon/resources/logs.ts`; the `throwOnError` default read from `packages/sdk/src/neon/config.ts`.

## For attention

- Logs are region-gated, not enrollment-gated: only `us-east-2` is enabled today, and a branch elsewhere returns `404` with reason `telemetry_not_enabled`. The CLI's own epilog still says logs "require Neon Platform Beta" — that string lives in `neon-pkgs` and now contradicts this, reported separately.
- The Loki surface is a read-only subset. It has no push endpoint and supports stream selectors and line filters, not aggregations, parsers, or formatting stages.
- The documented Loki base URL is verified for direct HTTP calls only. A Grafana data source appends `/loki/api/v1` to whatever URL it is configured with, so the correct data-source root is untested; the skill says so and tells the agent to confirm it against the docs rather than pasting the base.
- The coverage note needs editing twice more, once when Postgres compute logs ship and once for the AI Gateway. `neon-postgres` has no logs pointer and should get one at that time.
