### PR TITLE
Add metadata.source to skill frontmatter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@ This repo (`skills/`) is the source of truth. The Neon skills are also published
 
 - **OpenAI** — [`openai/plugins`](https://github.com/openai/plugins), Neon plugin at `plugins/neon-postgres/` (fork: `andrelandgraf/plugins`)
 - **Grok (xAI)** — [`xai-org/plugin-marketplace`](https://github.com/xai-org/plugin-marketplace), Neon plugin at `external_plugins/neon/` (fork: `andrelandgraf/plugin-marketplace`)
+- **JetBrains** — [`JetBrains/skills`](https://github.com/JetBrains/skills), top-level skill dirs (e.g. `neon/`, `neon-postgres/`); keep `metadata.source` pointing back here
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for the full sync checklist.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,12 +33,13 @@ The same pre-commit hook runs `npm run sync:versions` and stages the rewritten m
 
 The Neon skills are also published as plugins in external marketplaces that **vendor their own copies** of the skill files. Changes here do **not** propagate automatically. Whenever you add or change a skill, open a PR in each downstream marketplace to mirror the change:
 
-| Marketplace | Repo | Neon plugin path | Our fork |
+| Marketplace | Repo | Neon plugin / skill path | Our fork |
 | --- | --- | --- | --- |
 | OpenAI | [`openai/plugins`](https://github.com/openai/plugins) | `plugins/neon-postgres/` | `andrelandgraf/plugins` |
 | Grok (xAI) | [`xai-org/plugin-marketplace`](https://github.com/xai-org/plugin-marketplace) | `external_plugins/neon/` | `andrelandgraf/plugin-marketplace` |
+| JetBrains | [`JetBrains/skills`](https://github.com/JetBrains/skills) | Top-level skill dirs (e.g. `neon/`, `neon-postgres/`) | — |
 
-Each marketplace has its own packaging and validation steps — follow that repo's contributing guide when opening the mirror PR.
+Each marketplace has its own packaging and validation steps — follow that repo's contributing guide when opening the mirror PR. For JetBrains, copy each skill directory from `skills/` into a flat top-level directory in their catalog (include any `references/`), keep `metadata.source` pointing back here, and optionally add a README table row.
 
 ## Validation
 

--- a/plugins/neon-postgres/skills/claimable-postgres/SKILL.md
+++ b/plugins/neon-postgres/skills/claimable-postgres/SKILL.md
@@ -10,6 +10,7 @@ description: >-
   "neon.new API", "claimable postgres API".
 metadata:
   parent: neon
+  source: https://github.com/neondatabase/agent-skills/tree/main/skills/claimable-postgres
 ---
 
 **FIRST**: Use the parent `neon` skill for a Neon overview, getting started with Neon, Neon development best practices, and more.

--- a/plugins/neon-postgres/skills/neon-ai-gateway/SKILL.md
+++ b/plugins/neon-postgres/skills/neon-ai-gateway/SKILL.md
@@ -14,6 +14,7 @@ description: >-
   Gateway", and "log/rate-limit AI calls".
 metadata:
   parent: neon
+  source: https://github.com/neondatabase/agent-skills/tree/main/skills/neon-ai-gateway
 ---
 
 **FIRST**: Use the parent `neon` skill for a Neon overview, getting started with Neon, Neon development best practices, and more.

--- a/plugins/neon-postgres/skills/neon-functions/SKILL.md
+++ b/plugins/neon-postgres/skills/neon-functions/SKILL.md
@@ -14,6 +14,7 @@ description: >-
   "function logs", "Neon Functions", and "Neon Compute".
 metadata:
   parent: neon
+  source: https://github.com/neondatabase/agent-skills/tree/main/skills/neon-functions
 ---
 
 **FIRST**: Use the parent `neon` skill for a Neon overview, getting started with Neon, Neon development best practices, and more.

--- a/plugins/neon-postgres/skills/neon-object-storage/SKILL.md
+++ b/plugins/neon-postgres/skills/neon-object-storage/SKILL.md
@@ -14,6 +14,7 @@ description: >-
   branches with my database".
 metadata:
   parent: neon
+  source: https://github.com/neondatabase/agent-skills/tree/main/skills/neon-object-storage
 ---
 
 **FIRST**: Use the parent `neon` skill for a Neon overview, getting started with Neon, Neon development best practices, and more.

--- a/plugins/neon-postgres/skills/neon-postgres-branches/SKILL.md
+++ b/plugins/neon-postgres/skills/neon-postgres-branches/SKILL.md
@@ -11,6 +11,7 @@ description: >-
   "sensitive data testing".
 metadata:
   parent: neon
+  source: https://github.com/neondatabase/agent-skills/tree/main/skills/neon-postgres-branches
 ---
 
 **FIRST**: Use the parent `neon` skill for a Neon overview, getting started with Neon, Neon development best practices, and more.

--- a/plugins/neon-postgres/skills/neon-postgres-egress-optimizer/SKILL.md
+++ b/plugins/neon-postgres/skills/neon-postgres-egress-optimizer/SKILL.md
@@ -11,6 +11,7 @@ description: >-
   egress or data transfer.
 metadata:
   parent: neon
+  source: https://github.com/neondatabase/agent-skills/tree/main/skills/neon-postgres-egress-optimizer
 ---
 
 **FIRST**: Use the parent `neon` skill for a Neon overview, getting started with Neon, Neon development best practices, and more.

--- a/plugins/neon-postgres/skills/neon-postgres/SKILL.md
+++ b/plugins/neon-postgres/skills/neon-postgres/SKILL.md
@@ -13,6 +13,7 @@ description: >-
   "Neon connection pooling", or "schema migrations".
 metadata:
   parent: neon
+  source: https://github.com/neondatabase/agent-skills/tree/main/skills/neon-postgres
 ---
 
 **FIRST**: Use the parent `neon` skill for a Neon overview, getting started with Neon, Neon development best practices, and more.

--- a/plugins/neon-postgres/skills/neon/SKILL.md
+++ b/plugins/neon-postgres/skills/neon/SKILL.md
@@ -10,6 +10,8 @@ description: >-
   "AI gateway", "call an LLM", "logs", "branch logs", "query logs",
   "log export", "Loki", "Grafana", "observability", "telemetry", "postgres",
   "database", or "backend".
+metadata:
+  source: https://github.com/neondatabase/agent-skills/tree/main/skills/neon
 ---
 
 # Neon

--- a/skills/claimable-postgres/SKILL.md
+++ b/skills/claimable-postgres/SKILL.md
@@ -10,6 +10,7 @@ description: >-
   "neon.new API", "claimable postgres API".
 metadata:
   parent: neon
+  source: https://github.com/neondatabase/agent-skills/tree/main/skills/claimable-postgres
 ---
 
 **FIRST**: Use the parent `neon` skill for a Neon overview, getting started with Neon, Neon development best practices, and more.

--- a/skills/neon-ai-gateway/SKILL.md
+++ b/skills/neon-ai-gateway/SKILL.md
@@ -14,6 +14,7 @@ description: >-
   Gateway", and "log/rate-limit AI calls".
 metadata:
   parent: neon
+  source: https://github.com/neondatabase/agent-skills/tree/main/skills/neon-ai-gateway
 ---
 
 **FIRST**: Use the parent `neon` skill for a Neon overview, getting started with Neon, Neon development best practices, and more.

--- a/skills/neon-functions/SKILL.md
+++ b/skills/neon-functions/SKILL.md
@@ -14,6 +14,7 @@ description: >-
   "function logs", "Neon Functions", and "Neon Compute".
 metadata:
   parent: neon
+  source: https://github.com/neondatabase/agent-skills/tree/main/skills/neon-functions
 ---
 
 **FIRST**: Use the parent `neon` skill for a Neon overview, getting started with Neon, Neon development best practices, and more.

--- a/skills/neon-object-storage/SKILL.md
+++ b/skills/neon-object-storage/SKILL.md
@@ -14,6 +14,7 @@ description: >-
   branches with my database".
 metadata:
   parent: neon
+  source: https://github.com/neondatabase/agent-skills/tree/main/skills/neon-object-storage
 ---
 
 **FIRST**: Use the parent `neon` skill for a Neon overview, getting started with Neon, Neon development best practices, and more.

--- a/skills/neon-postgres-branches/SKILL.md
+++ b/skills/neon-postgres-branches/SKILL.md
@@ -11,6 +11,7 @@ description: >-
   "sensitive data testing".
 metadata:
   parent: neon
+  source: https://github.com/neondatabase/agent-skills/tree/main/skills/neon-postgres-branches
 ---
 
 **FIRST**: Use the parent `neon` skill for a Neon overview, getting started with Neon, Neon development best practices, and more.

--- a/skills/neon-postgres-egress-optimizer/SKILL.md
+++ b/skills/neon-postgres-egress-optimizer/SKILL.md
@@ -11,6 +11,7 @@ description: >-
   egress or data transfer.
 metadata:
   parent: neon
+  source: https://github.com/neondatabase/agent-skills/tree/main/skills/neon-postgres-egress-optimizer
 ---
 
 **FIRST**: Use the parent `neon` skill for a Neon overview, getting started with Neon, Neon development best practices, and more.

--- a/skills/neon-postgres/SKILL.md
+++ b/skills/neon-postgres/SKILL.md
@@ -13,6 +13,7 @@ description: >-
   "Neon connection pooling", or "schema migrations".
 metadata:
   parent: neon
+  source: https://github.com/neondatabase/agent-skills/tree/main/skills/neon-postgres
 ---
 
 **FIRST**: Use the parent `neon` skill for a Neon overview, getting started with Neon, Neon development best practices, and more.

--- a/skills/neon/SKILL.md
+++ b/skills/neon/SKILL.md
@@ -10,6 +10,8 @@ description: >-
   "AI gateway", "call an LLM", "logs", "branch logs", "query logs",
   "log export", "Loki", "Grafana", "observability", "telemetry", "postgres",
   "database", or "backend".
+metadata:
+  source: https://github.com/neondatabase/agent-skills/tree/main/skills/neon
 ---
 
 # Neon


### PR DESCRIPTION
## Summary
- Add `metadata.source` to every skill under `skills/`, pointing at the skill’s path in this repo.
- Sync the vendored copies under `plugins/neon-postgres/skills/`.

## Test plan
- [ ] Confirm each `skills/*/SKILL.md` frontmatter includes `metadata.source`
- [ ] Confirm vendored plugin copies match (`npm run validate:plugin-skills`)
- [ ] CI `validate:ci` passes