### PR TITLE
Recommend a pg pool error listener on Neon Functions

### DIFF
--- a/plugins/neon-postgres/skills/neon-functions/SKILL.md
+++ b/plugins/neon-postgres/skills/neon-functions/SKILL.md
@@ -215,7 +215,7 @@ attachDatabasePool(pool);
 const db = drizzle(pool);
 ```
 
-node-postgres emits idle-client failures as `error` on the pool. With no listener that is an `uncaughtException` and Node exits the isolate. Call `attachDatabasePool(pool)` once after `new Pool`. Expected idle disconnects (`ECONNRESET`, `EPIPE`, `ETIMEDOUT`, Postgres `57P01`, node-postgres's `Connection terminated unexpectedly`) are silent. Anything else is `console.error`, or `onUnexpectedError` if you pass it on the first call. The first call wins; a later call that passes `onUnexpectedError` is ignored and warns. This does not close the pool.
+node-postgres emits idle-client failures as `error` on the pool. With no listener that is an `uncaughtException` and Node exits the isolate. Call `attachDatabasePool(pool)` once after `new Pool`. Requires `@neon/functions` ≥ 0.8.0. Expected idle disconnects (`ECONNRESET`, `EPIPE`, `ETIMEDOUT`, Postgres `57P01`, node-postgres's `Connection terminated unexpectedly`) are silent. Anything else is `console.error`, or `onUnexpectedError` if you pass it on the first call. The first call wins; a later call that passes `onUnexpectedError` is ignored and warns. This does not close the pool.
 
 **Pooling is recommended because an isolate is reused across many requests** (and several requests can be in flight on the same isolate at once — see [Timeouts and Runtime Limits](#timeouts-and-runtime-limits)). A module-scope pool is opened once on cold start and then shared by every subsequent request that isolate serves, so you amortize connection setup instead of paying it on every request and you avoid exhausting Postgres connections under load.
 
@@ -483,9 +483,10 @@ async function connect() {
   const token = await getToken(); // re-mint each attempt; short-lived
   const ws = new WebSocket(`${WS_URL}?token=${encodeURIComponent(token)}`);
   ws.onopen = () => {
-    retry = 0;
+    retry = 0; // reset backoff on success
   };
   ws.onmessage = (e) => {
+    /* apply the event */
   };
   ws.onclose = () => {
     if (!closed)

--- a/plugins/neon-postgres/skills/neon-functions/SKILL.md
+++ b/plugins/neon-postgres/skills/neon-functions/SKILL.md
@@ -242,7 +242,7 @@ pool.on("error", (err) => {
 const db = drizzle(pool);
 ```
 
-node-postgres emits idle-client failures as `error` on the pool. With no listener that is an `uncaughtException` and Node exits the isolate. Expected idle drops — TCP reset (`ECONNRESET` / `EPIPE` / `ETIMEDOUT`), Postgres admin shutdown (`57P01`, compute scale-to-zero), and pg's `Connection terminated unexpectedly` — are silent. Anything else is logged.
+node-postgres emits idle-client failures as `error` on the pool. With no listener that is an `uncaughtException` and Node exits the isolate. pg's own idle timer (`idleTimeoutMillis`, default 10s) closes idle clients cleanly and does not emit `error`. This listener is for the server or an intermediary closing a client that is still in the pool. Expected idle drops — TCP reset (`ECONNRESET` / `EPIPE` / `ETIMEDOUT`), Postgres admin shutdown (`57P01`, compute scale-to-zero), and pg's `Connection terminated unexpectedly` — are silent. Anything else is logged.
 
 **Pooling is recommended because an isolate is reused across many requests** (and several requests can be in flight on the same isolate at once — see [Timeouts and Runtime Limits](#timeouts-and-runtime-limits)). A module-scope pool is opened once on cold start and then shared by every subsequent request that isolate serves, so you amortize connection setup instead of paying it on every request and you avoid exhausting Postgres connections under load.
 
@@ -470,6 +470,9 @@ const CHANNEL = "chat_events";
 // One dedicated DIRECT connection per isolate, just to receive events.
 // Use DATABASE_URL_UNPOOLED — LISTEN needs a real session, not a pooled one.
 const listener = new Client({ connectionString: process.env.DATABASE_URL_UNPOOLED });
+listener.on("error", (err) => {
+  if (!isIdleDisconnect(err)) console.error(err);
+});
 listener.connect().then(() => listener.query(`LISTEN ${CHANNEL}`));
 listener.on("notification", (msg) => {
   if (!msg.payload) return;

--- a/plugins/neon-postgres/skills/neon-functions/SKILL.md
+++ b/plugins/neon-postgres/skills/neon-functions/SKILL.md
@@ -100,8 +100,22 @@ import { parseEnv } from "@neon/env";
 import config from "../neon";
 import { todos } from "./db/schema";
 
+const PG_ADMIN_SHUTDOWN = "57P01";
+const IDLE_DISCONNECT_CODES = new Set(["ECONNRESET", "EPIPE", "ETIMEDOUT", PG_ADMIN_SHUTDOWN]);
+
+function isIdleDisconnect(err: Error): boolean {
+  const code = "code" in err && typeof err.code === "string" ? err.code : undefined;
+  return (
+    (code !== undefined && IDLE_DISCONNECT_CODES.has(code)) ||
+    err.message === "Connection terminated unexpectedly"
+  );
+}
+
 const env = parseEnv(config);
 const pool = new Pool({ connectionString: env.postgres.databaseUrl, max: 5 });
+pool.on("error", (err) => {
+  if (!isIdleDisconnect(err)) console.error(err);
+});
 const db = drizzle(pool);
 
 const app = new Hono();
@@ -116,13 +130,16 @@ app.get("/todos", async (c) => c.json(await db.select().from(todos)));
 export default app;
 ```
 
-Create the `pg` pool at module scope (reused across requests on the same isolate) and keep `max` small (e.g. 5), since each isolate keeps its own pool.
+Create the `pg` pool at module scope (reused across requests on the same isolate) and keep `max` small (e.g. 5), since each isolate keeps its own pool. Attach a pool `error` listener so an idle disconnect is not an `uncaughtException` — see [Connecting to Postgres](#connecting-to-postgres).
 
 `parseEnv(config)` requires _every_ variable the config implies. A function that only talks to Postgres over the pooled URL can scope it to just that key — `parseEnv` then validates and returns only what you asked for (the keys autocomplete from your `neon.ts`):
 
 ```typescript
 const { postgres } = parseEnv(config, ["DATABASE_URL"]); // not the unpooled URL, auth, etc.
 const pool = new Pool({ connectionString: postgres.databaseUrl, max: 5 });
+pool.on("error", (err) => {
+  if (!isIdleDisconnect(err)) console.error(err);
+});
 ```
 
 ## Develop Locally and Deploy
@@ -206,10 +223,26 @@ Create the connection pool **once at module scope** and reuse it across requests
 import { drizzle } from "drizzle-orm/node-postgres";
 import { Pool } from "pg";
 
+const PG_ADMIN_SHUTDOWN = "57P01";
+const IDLE_DISCONNECT_CODES = new Set(["ECONNRESET", "EPIPE", "ETIMEDOUT", PG_ADMIN_SHUTDOWN]);
+
+function isIdleDisconnect(err: Error): boolean {
+  const code = "code" in err && typeof err.code === "string" ? err.code : undefined;
+  return (
+    (code !== undefined && IDLE_DISCONNECT_CODES.has(code)) ||
+    err.message === "Connection terminated unexpectedly"
+  );
+}
+
 // Created once per isolate; reused by every request that isolate handles.
 const pool = new Pool({ connectionString: process.env.DATABASE_URL, max: 5 });
+pool.on("error", (err) => {
+  if (!isIdleDisconnect(err)) console.error(err);
+});
 const db = drizzle(pool);
 ```
+
+node-postgres emits idle-client failures as `error` on the pool. With no listener that is an `uncaughtException` and Node exits the isolate. Expected idle drops — TCP reset (`ECONNRESET` / `EPIPE` / `ETIMEDOUT`), Postgres admin shutdown (`57P01`, compute scale-to-zero), and pg's `Connection terminated unexpectedly` — are silent. Anything else is logged.
 
 **Pooling is recommended because an isolate is reused across many requests** (and several requests can be in flight on the same isolate at once — see [Timeouts and Runtime Limits](#timeouts-and-runtime-limits)). A module-scope pool is opened once on cold start and then shared by every subsequent request that isolate serves, so you amortize connection setup instead of paying it on every request and you avoid exhausting Postgres connections under load.
 
@@ -418,6 +451,9 @@ poller.unref?.();
 import { Pool, Client } from "pg";
 
 const pool = new Pool({ connectionString: process.env.DATABASE_URL, max: 5 });
+pool.on("error", (err) => {
+  if (!isIdleDisconnect(err)) console.error(err);
+});
 const CHANNEL = "chat_events";
 
 // One dedicated DIRECT connection per isolate, just to receive events.

--- a/plugins/neon-postgres/skills/neon-functions/SKILL.md
+++ b/plugins/neon-postgres/skills/neon-functions/SKILL.md
@@ -469,6 +469,7 @@ const CHANNEL = "chat_events";
 
 // One dedicated DIRECT connection per isolate, just to receive events.
 // Use DATABASE_URL_UNPOOLED — LISTEN needs a real session, not a pooled one.
+// An error listener keeps the isolate alive; the feed stays down until the isolate restarts.
 const listener = new Client({ connectionString: process.env.DATABASE_URL_UNPOOLED });
 listener.on("error", (err) => {
   if (!isIdleDisconnect(err)) console.error(err);

--- a/plugins/neon-postgres/skills/neon-functions/SKILL.md
+++ b/plugins/neon-postgres/skills/neon-functions/SKILL.md
@@ -450,6 +450,17 @@ poller.unref?.();
 ```typescript
 import { Pool, Client } from "pg";
 
+const PG_ADMIN_SHUTDOWN = "57P01";
+const IDLE_DISCONNECT_CODES = new Set(["ECONNRESET", "EPIPE", "ETIMEDOUT", PG_ADMIN_SHUTDOWN]);
+
+function isIdleDisconnect(err: Error): boolean {
+  const code = "code" in err && typeof err.code === "string" ? err.code : undefined;
+  return (
+    (code !== undefined && IDLE_DISCONNECT_CODES.has(code)) ||
+    err.message === "Connection terminated unexpectedly"
+  );
+}
+
 const pool = new Pool({ connectionString: process.env.DATABASE_URL, max: 5 });
 pool.on("error", (err) => {
   if (!isIdleDisconnect(err)) console.error(err);

--- a/plugins/neon-postgres/skills/neon-functions/SKILL.md
+++ b/plugins/neon-postgres/skills/neon-functions/SKILL.md
@@ -97,25 +97,13 @@ import { Hono } from "hono";
 import { drizzle } from "drizzle-orm/node-postgres";
 import { Pool } from "pg";
 import { parseEnv } from "@neon/env";
+import { attachDatabasePool } from "@neon/functions";
 import config from "../neon";
 import { todos } from "./db/schema";
 
-const PG_ADMIN_SHUTDOWN = "57P01";
-const IDLE_DISCONNECT_CODES = new Set(["ECONNRESET", "EPIPE", "ETIMEDOUT", PG_ADMIN_SHUTDOWN]);
-
-function isIdleDisconnect(err: Error): boolean {
-  const code = "code" in err && typeof err.code === "string" ? err.code : undefined;
-  return (
-    (code !== undefined && IDLE_DISCONNECT_CODES.has(code)) ||
-    err.message === "Connection terminated unexpectedly"
-  );
-}
-
 const env = parseEnv(config);
 const pool = new Pool({ connectionString: env.postgres.databaseUrl, max: 5 });
-pool.on("error", (err) => {
-  if (!isIdleDisconnect(err)) console.error(err);
-});
+attachDatabasePool(pool);
 const db = drizzle(pool);
 
 const app = new Hono();
@@ -130,16 +118,14 @@ app.get("/todos", async (c) => c.json(await db.select().from(todos)));
 export default app;
 ```
 
-Create the `pg` pool at module scope (reused across requests on the same isolate) and keep `max` small (e.g. 5), since each isolate keeps its own pool. Attach a pool `error` listener so an idle disconnect is not an `uncaughtException` — see [Connecting to Postgres](#connecting-to-postgres).
+Create the `pg` pool at module scope (reused across requests on the same isolate) and keep `max` small (e.g. 5), since each isolate keeps its own pool. Call `attachDatabasePool(pool)` so an idle disconnect is not an `uncaughtException` — see [Connecting to Postgres](#connecting-to-postgres).
 
 `parseEnv(config)` requires _every_ variable the config implies. A function that only talks to Postgres over the pooled URL can scope it to just that key — `parseEnv` then validates and returns only what you asked for (the keys autocomplete from your `neon.ts`):
 
 ```typescript
 const { postgres } = parseEnv(config, ["DATABASE_URL"]); // not the unpooled URL, auth, etc.
 const pool = new Pool({ connectionString: postgres.databaseUrl, max: 5 });
-pool.on("error", (err) => {
-  if (!isIdleDisconnect(err)) console.error(err);
-});
+attachDatabasePool(pool);
 ```
 
 ## Develop Locally and Deploy
@@ -182,13 +168,13 @@ export default defineConfig({
 
 Neon injects branch-scoped connection strings and service URLs at runtime — you don't declare these or pass them at deploy time:
 
-| Variable                | Notes                                                                                    |
-| ----------------------- | ---------------------------------------------------------------------------------------- |
+| Variable                | Notes                                                                                              |
+| ----------------------- | -------------------------------------------------------------------------------------------------- |
 | `NEON_BRANCH`           | The branch **name** (e.g. `main`, `preview/foo`). Injected on every branch, including the default. |
-| `DATABASE_URL`          | Pooled connection string. Use for most queries. Present only if the branch has Postgres. |
-| `DATABASE_URL_UNPOOLED` | Direct connection. Use for migrations, `LISTEN`/`NOTIFY`, multi-round-trip transactions. |
-| `NEON_AUTH_BASE_URL`    | Present when Neon Auth is enabled on the branch.                                         |
-| `NEON_DATA_API_URL`     | Present when the Data API is enabled on the branch.                                      |
+| `DATABASE_URL`          | Pooled connection string. Use for most queries. Present only if the branch has Postgres.           |
+| `DATABASE_URL_UNPOOLED` | Direct connection. Use for migrations, `LISTEN`/`NOTIFY`, multi-round-trip transactions.           |
+| `NEON_AUTH_BASE_URL`    | Present when Neon Auth is enabled on the branch.                                                   |
+| `NEON_DATA_API_URL`     | Present when the Data API is enabled on the branch.                                                |
 
 Object storage (`AWS_*`) and AI Gateway (`NEON_AI_GATEWAY_*`) vars are also injected when those services are declared — see the `neon-object-storage` and `neon-ai-gateway` skills.
 
@@ -220,29 +206,16 @@ When the branch has Postgres, Neon **injects the connection strings at runtime**
 Create the connection pool **once at module scope** and reuse it across requests — don't open a connection per request:
 
 ```typescript
+import { attachDatabasePool } from "@neon/functions";
 import { drizzle } from "drizzle-orm/node-postgres";
 import { Pool } from "pg";
 
-const PG_ADMIN_SHUTDOWN = "57P01";
-const IDLE_DISCONNECT_CODES = new Set(["ECONNRESET", "EPIPE", "ETIMEDOUT", PG_ADMIN_SHUTDOWN]);
-
-function isIdleDisconnect(err: Error): boolean {
-  const code = "code" in err && typeof err.code === "string" ? err.code : undefined;
-  return (
-    (code !== undefined && IDLE_DISCONNECT_CODES.has(code)) ||
-    err.message === "Connection terminated unexpectedly"
-  );
-}
-
-// Created once per isolate; reused by every request that isolate handles.
 const pool = new Pool({ connectionString: process.env.DATABASE_URL, max: 5 });
-pool.on("error", (err) => {
-  if (!isIdleDisconnect(err)) console.error(err);
-});
+attachDatabasePool(pool);
 const db = drizzle(pool);
 ```
 
-node-postgres emits idle-client failures as `error` on the pool. With no listener that is an `uncaughtException` and Node exits the isolate. pg's own idle timer (`idleTimeoutMillis`, default 10s) closes idle clients cleanly and does not emit `error`. This listener is for the server or an intermediary closing a client that is still in the pool. Expected idle drops — TCP reset (`ECONNRESET` / `EPIPE` / `ETIMEDOUT`), Postgres admin shutdown (`57P01`, compute scale-to-zero), and pg's `Connection terminated unexpectedly` — are silent. Anything else is logged.
+node-postgres emits idle-client failures as `error` on the pool. With no listener that is an `uncaughtException` and Node exits the isolate. Call `attachDatabasePool(pool)` once after `new Pool`. Expected idle disconnects (`ECONNRESET`, `EPIPE`, `ETIMEDOUT`, Postgres `57P01`, node-postgres's `Connection terminated unexpectedly`) are silent. Anything else is `console.error`, or `onUnexpectedError` if you pass it on the first call. The first call wins; a later call that passes `onUnexpectedError` is ignored and warns. This does not close the pool.
 
 **Pooling is recommended because an isolate is reused across many requests** (and several requests can be in flight on the same isolate at once — see [Timeouts and Runtime Limits](#timeouts-and-runtime-limits)). A module-scope pool is opened once on cold start and then shared by every subsequent request that isolate serves, so you amortize connection setup instead of paying it on every request and you avoid exhausting Postgres connections under load.
 
@@ -284,15 +257,21 @@ Browser ──▶ your app backend ──▶ Neon Function                      
 // src/index.ts — verify the caller before doing any work
 import { createRemoteJWKSet, jwtVerify } from "jose";
 
-const jwks = createRemoteJWKSet(new URL(`${process.env.AUTH_BASE_URL}/api/auth/jwks`));
+const jwks = createRemoteJWKSet(
+  new URL(`${process.env.AUTH_BASE_URL}/api/auth/jwks`),
+);
 
 export default {
   async fetch(request: Request) {
-    if (request.method === "OPTIONS") return new Response(null, { status: 204, headers: cors(request) });
+    if (request.method === "OPTIONS")
+      return new Response(null, { status: 204, headers: cors(request) });
 
     const auth = request.headers.get("authorization");
     if (!auth?.toLowerCase().startsWith("bearer ")) {
-      return new Response("Unauthorized", { status: 401, headers: cors(request) });
+      return new Response("Unauthorized", {
+        status: 401,
+        headers: cors(request),
+      });
     }
     try {
       const { payload } = await jwtVerify(auth.slice(7), jwks, {
@@ -302,7 +281,10 @@ export default {
       const userId = payload.sub; // scope the agent to this user
       // ... run the agent, return result.toUIMessageStreamResponse({ headers: cors(request) })
     } catch {
-      return new Response("Unauthorized", { status: 401, headers: cors(request) });
+      return new Response("Unauthorized", {
+        status: 401,
+        headers: cors(request),
+      });
     }
   },
 };
@@ -389,7 +371,9 @@ app.get("/ws", async (c) => {
 
   const { socket, response } = upgradeWebSocket(c.req.raw);
   socket.addEventListener("open", () => socket.send("welcome"));
-  socket.addEventListener("message", (event) => socket.send(`echo: ${event.data}`));
+  socket.addEventListener("message", (event) =>
+    socket.send(`echo: ${event.data}`),
+  );
   return response;
 });
 
@@ -448,31 +432,21 @@ poller.unref?.();
 **2. `LISTEN`/`NOTIFY` — lowest latency, but requires disabling Scale to Zero.** Each isolate `LISTEN`s on a channel over a dedicated **unpooled** connection; broadcasting is `NOTIFY`, so every isolate (including the sender's) re-pushes to its sockets. Near-instant — but the listener holds an idle connection that **does not count as active**, so [Scale to Zero](https://neon.com/docs/introduction/scale-to-zero) suspends the compute and drops it, silently killing the feed. Only use it on an **always-on** compute (Scale to Zero disabled — a paid-plan setting).
 
 ```typescript
+import { attachDatabasePool } from "@neon/functions";
 import { Pool, Client } from "pg";
 
-const PG_ADMIN_SHUTDOWN = "57P01";
-const IDLE_DISCONNECT_CODES = new Set(["ECONNRESET", "EPIPE", "ETIMEDOUT", PG_ADMIN_SHUTDOWN]);
-
-function isIdleDisconnect(err: Error): boolean {
-  const code = "code" in err && typeof err.code === "string" ? err.code : undefined;
-  return (
-    (code !== undefined && IDLE_DISCONNECT_CODES.has(code)) ||
-    err.message === "Connection terminated unexpectedly"
-  );
-}
-
 const pool = new Pool({ connectionString: process.env.DATABASE_URL, max: 5 });
-pool.on("error", (err) => {
-  if (!isIdleDisconnect(err)) console.error(err);
-});
+attachDatabasePool(pool);
 const CHANNEL = "chat_events";
 
 // One dedicated DIRECT connection per isolate, just to receive events.
 // Use DATABASE_URL_UNPOOLED — LISTEN needs a real session, not a pooled one.
 // An error listener keeps the isolate alive; the feed stays down until the isolate restarts.
-const listener = new Client({ connectionString: process.env.DATABASE_URL_UNPOOLED });
+const listener = new Client({
+  connectionString: process.env.DATABASE_URL_UNPOOLED,
+});
 listener.on("error", (err) => {
-  if (!isIdleDisconnect(err)) console.error(err);
+  console.error(err);
 });
 listener.connect().then(() => listener.query(`LISTEN ${CHANNEL}`));
 listener.on("notification", (msg) => {
@@ -484,7 +458,10 @@ listener.on("notification", (msg) => {
 
 // Broadcast by NOTIFYing through the pool — every isolate's listener fires.
 function broadcast(event: unknown) {
-  return pool.query("SELECT pg_notify($1, $2)", [CHANNEL, JSON.stringify(event)]);
+  return pool.query("SELECT pg_notify($1, $2)", [
+    CHANNEL,
+    JSON.stringify(event),
+  ]);
 }
 ```
 
@@ -497,18 +474,25 @@ function broadcast(event: unknown) {
 Idle functions are evicted (and isolates restart for operational reasons), so a client's socket **will** drop — treat reconnection as normal, not exceptional. Reconnect with exponential backoff, capped, and **re-mint a fresh token on every attempt** (tokens are short-lived, so a stale one fails the `upgrade` auth check):
 
 ```typescript
-let closed = false, retry = 0, timer: ReturnType<typeof setTimeout>;
+let closed = false,
+  retry = 0,
+  timer: ReturnType<typeof setTimeout>;
 
 async function connect() {
   if (closed) return;
   const token = await getToken(); // re-mint each attempt; short-lived
   const ws = new WebSocket(`${WS_URL}?token=${encodeURIComponent(token)}`);
-  ws.onopen = () => { retry = 0; };          // reset backoff on success
-  ws.onmessage = (e) => { /* apply the event */ };
-  ws.onclose = () => {
-    if (!closed) timer = setTimeout(connect, Math.min(1000 * 2 ** retry++, 15000));
+  ws.onopen = () => {
+    retry = 0;
+  }; // reset backoff on success
+  ws.onmessage = (e) => {
+    /* apply the event */
   };
-  ws.onerror = () => ws.close();             // let onclose drive the retry
+  ws.onclose = () => {
+    if (!closed)
+      timer = setTimeout(connect, Math.min(1000 * 2 ** retry++, 15000));
+  };
+  ws.onerror = () => ws.close(); // let onclose drive the retry
 }
 connect();
 ```
@@ -528,11 +512,19 @@ export default {
       new ReadableStream<Uint8Array>({
         start(controller) {
           controller.enqueue(encoder.encode("data: hello\n\n"));
-          const t = setInterval(() => controller.enqueue(encoder.encode(": ping\n\n")), 25_000);
+          const t = setInterval(
+            () => controller.enqueue(encoder.encode(": ping\n\n")),
+            25_000,
+          );
           return () => clearInterval(t); // fires when the client disconnects
         },
       }),
-      { headers: { "Content-Type": "text/event-stream", "Cache-Control": "no-cache, no-transform" } },
+      {
+        headers: {
+          "Content-Type": "text/event-stream",
+          "Cache-Control": "no-cache, no-transform",
+        },
+      },
     ),
 };
 ```

--- a/plugins/neon-postgres/skills/neon-functions/SKILL.md
+++ b/plugins/neon-postgres/skills/neon-functions/SKILL.md
@@ -484,9 +484,8 @@ async function connect() {
   const ws = new WebSocket(`${WS_URL}?token=${encodeURIComponent(token)}`);
   ws.onopen = () => {
     retry = 0;
-  }; // reset backoff on success
+  };
   ws.onmessage = (e) => {
-    /* apply the event */
   };
   ws.onclose = () => {
     if (!closed)

--- a/plugins/neon-postgres/skills/neon-functions/SKILL.md
+++ b/plugins/neon-postgres/skills/neon-functions/SKILL.md
@@ -441,6 +441,7 @@ const CHANNEL = "chat_events";
 
 // One dedicated DIRECT connection per isolate, just to receive events.
 // Use DATABASE_URL_UNPOOLED — LISTEN needs a real session, not a pooled one.
+// Don't call attachDatabasePool here: it would silence the idle drop that killed the feed.
 // An error listener keeps the isolate alive; the feed stays down until the isolate restarts.
 const listener = new Client({
   connectionString: process.env.DATABASE_URL_UNPOOLED,

--- a/plugins/neon-postgres/skills/neon-functions/references/ai-sdk.md
+++ b/plugins/neon-postgres/skills/neon-functions/references/ai-sdk.md
@@ -32,27 +32,15 @@ The function's default export is a web-standard `{ fetch }` handler. The `@neon/
 ```typescript
 // src/index.ts
 import { neon } from "@neon/ai-sdk-provider";
+import { attachDatabasePool } from "@neon/functions";
 import { streamText, tool, stepCountIs, type ModelMessage } from "ai";
 import { z } from "zod";
 import { drizzle } from "drizzle-orm/node-postgres";
 import { Pool } from "pg";
 import { todos } from "./db/schema";
 
-const PG_ADMIN_SHUTDOWN = "57P01";
-const IDLE_DISCONNECT_CODES = new Set(["ECONNRESET", "EPIPE", "ETIMEDOUT", PG_ADMIN_SHUTDOWN]);
-
-function isIdleDisconnect(err: Error): boolean {
-  const code = "code" in err && typeof err.code === "string" ? err.code : undefined;
-  return (
-    (code !== undefined && IDLE_DISCONNECT_CODES.has(code)) ||
-    err.message === "Connection terminated unexpectedly"
-  );
-}
-
 const pool = new Pool({ connectionString: process.env.DATABASE_URL, max: 5 });
-pool.on("error", (err) => {
-  if (!isIdleDisconnect(err)) console.error(err);
-});
+attachDatabasePool(pool);
 const db = drizzle(pool);
 
 export default {
@@ -82,7 +70,8 @@ export default {
     });
 
     return result.toUIMessageStreamResponse({
-      onError: (error) => (error instanceof Error ? error.message : String(error)),
+      onError: (error) =>
+        error instanceof Error ? error.message : String(error),
     });
   },
 };
@@ -105,7 +94,8 @@ const files = new Files({ adapter: neonFiles({ bucket: "images" }) });
 
 const result = streamText({
   model: neon("gpt-5-mini"),
-  system: "Use image_generation when the user asks for a picture, then describe it.",
+  system:
+    "Use image_generation when the user asks for a picture, then describe it.",
   messages,
   tools: {
     image_generation: neon.tools.imageGeneration({
@@ -120,7 +110,9 @@ const result = streamText({
       const base64 = imageResultBase64(tr.output);
       if (!base64) continue;
       const key = `generated/${randomUUID()}.jpg`;
-      await files.upload(key, Buffer.from(base64, "base64"), { contentType: "image/jpeg" });
+      await files.upload(key, Buffer.from(base64, "base64"), {
+        contentType: "image/jpeg",
+      });
       // …insert a row keyed by `key` into Postgres; serve later via files.url(key)
     }
   },

--- a/plugins/neon-postgres/skills/neon-functions/references/ai-sdk.md
+++ b/plugins/neon-postgres/skills/neon-functions/references/ai-sdk.md
@@ -38,7 +38,21 @@ import { drizzle } from "drizzle-orm/node-postgres";
 import { Pool } from "pg";
 import { todos } from "./db/schema";
 
+const PG_ADMIN_SHUTDOWN = "57P01";
+const IDLE_DISCONNECT_CODES = new Set(["ECONNRESET", "EPIPE", "ETIMEDOUT", PG_ADMIN_SHUTDOWN]);
+
+function isIdleDisconnect(err: Error): boolean {
+  const code = "code" in err && typeof err.code === "string" ? err.code : undefined;
+  return (
+    (code !== undefined && IDLE_DISCONNECT_CODES.has(code)) ||
+    err.message === "Connection terminated unexpectedly"
+  );
+}
+
 const pool = new Pool({ connectionString: process.env.DATABASE_URL, max: 5 });
+pool.on("error", (err) => {
+  if (!isIdleDisconnect(err)) console.error(err);
+});
 const db = drizzle(pool);
 
 export default {

--- a/plugins/neon-postgres/skills/neon-functions/references/mcp.md
+++ b/plugins/neon-postgres/skills/neon-functions/references/mcp.md
@@ -133,7 +133,7 @@ Either way it's one check at the top of the `/mcp` route — reject anything tha
 app.all("/mcp", async (c) => {
   const auth = c.req.header("authorization");
   if (!(await isValidApiKey(auth)))
-    return c.json({ error: "unauthorized" }, 401); // your check
+    return c.json({ error: "unauthorized" }, 401);
   if (!mcpServer.isConnected()) await mcpServer.connect(transport);
   return transport.handleRequest(c);
 });

--- a/plugins/neon-postgres/skills/neon-functions/references/mcp.md
+++ b/plugins/neon-postgres/skills/neon-functions/references/mcp.md
@@ -19,8 +19,22 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StreamableHTTPTransport } from "@hono/mcp";
 import { contacts } from "./db/schema";
 
+const PG_ADMIN_SHUTDOWN = "57P01";
+const IDLE_DISCONNECT_CODES = new Set(["ECONNRESET", "EPIPE", "ETIMEDOUT", PG_ADMIN_SHUTDOWN]);
+
+function isIdleDisconnect(err: Error): boolean {
+  const code = "code" in err && typeof err.code === "string" ? err.code : undefined;
+  return (
+    (code !== undefined && IDLE_DISCONNECT_CODES.has(code)) ||
+    err.message === "Connection terminated unexpectedly"
+  );
+}
+
 // One pool per isolate, reused across requests.
 const pool = new Pool({ connectionString: process.env.DATABASE_URL, max: 5 });
+pool.on("error", (err) => {
+  if (!isIdleDisconnect(err)) console.error(err);
+});
 const db = drizzle(pool);
 
 const mcpServer = new McpServer({ name: "contacts", version: "1.0.0" });

--- a/plugins/neon-postgres/skills/neon-functions/references/mcp.md
+++ b/plugins/neon-postgres/skills/neon-functions/references/mcp.md
@@ -17,24 +17,11 @@ import { eq } from "drizzle-orm";
 import { z } from "zod";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StreamableHTTPTransport } from "@hono/mcp";
+import { attachDatabasePool } from "@neon/functions";
 import { contacts } from "./db/schema";
 
-const PG_ADMIN_SHUTDOWN = "57P01";
-const IDLE_DISCONNECT_CODES = new Set(["ECONNRESET", "EPIPE", "ETIMEDOUT", PG_ADMIN_SHUTDOWN]);
-
-function isIdleDisconnect(err: Error): boolean {
-  const code = "code" in err && typeof err.code === "string" ? err.code : undefined;
-  return (
-    (code !== undefined && IDLE_DISCONNECT_CODES.has(code)) ||
-    err.message === "Connection terminated unexpectedly"
-  );
-}
-
-// One pool per isolate, reused across requests.
 const pool = new Pool({ connectionString: process.env.DATABASE_URL, max: 5 });
-pool.on("error", (err) => {
-  if (!isIdleDisconnect(err)) console.error(err);
-});
+attachDatabasePool(pool);
 const db = drizzle(pool);
 
 const mcpServer = new McpServer({ name: "contacts", version: "1.0.0" });
@@ -66,8 +53,15 @@ mcpServer.registerTool(
     inputSchema: { id: z.number().int().positive() },
   },
   async ({ id }) => {
-    const [row] = await db.delete(contacts).where(eq(contacts.id, id)).returning();
-    return { content: [{ type: "text", text: JSON.stringify(row ?? { error: "not found" }) }] };
+    const [row] = await db
+      .delete(contacts)
+      .where(eq(contacts.id, id))
+      .returning();
+    return {
+      content: [
+        { type: "text", text: JSON.stringify(row ?? { error: "not found" }) },
+      ],
+    };
   },
 );
 
@@ -138,7 +132,8 @@ Either way it's one check at the top of the `/mcp` route — reject anything tha
 ```typescript
 app.all("/mcp", async (c) => {
   const auth = c.req.header("authorization");
-  if (!(await isValidApiKey(auth))) return c.json({ error: "unauthorized" }, 401); // your check
+  if (!(await isValidApiKey(auth)))
+    return c.json({ error: "unauthorized" }, 401); // your check
   if (!mcpServer.isConnected()) await mcpServer.connect(transport);
   return transport.handleRequest(c);
 });

--- a/plugins/neon-postgres/skills/neon-functions/references/sentry.md
+++ b/plugins/neon-postgres/skills/neon-functions/references/sentry.md
@@ -10,7 +10,7 @@ Because the runtime is a normal Node process, use the Node SDK `@sentry/node` �
 
 Sentry has distinct signals, and picking the right one is the main instrumentation decision:
 
-1. **Errors** — unhandled route errors and failures your code can't recover from. Each becomes a grouped, alertable *issue*.
+1. **Errors** — unhandled route errors and failures your code can't recover from. Each becomes a grouped, alertable _issue_.
 2. **Logs** — recoverable failures and narrative events (a model attempt failed and the agent moved on, a retry, a fallback). Structured, searchable, linked to the trace — and they don't pollute the issue stream.
 3. **Traces** — the request's span tree: the incoming request, outbound fetches, and (for agents) the full model/tool call hierarchy with token usage.
 
@@ -18,12 +18,12 @@ All three carry the same trace ID, so from an error you can pivot to the logs an
 
 ### Environment variables
 
-| Variable | Purpose |
-| --- | --- |
-| `SENTRY_DSN` | Project DSN; keep it configurable through the deployment environment. |
-| `SENTRY_RELEASE` | Optional release identifier such as a commit SHA — unlocks regression detection. |
+| Variable                    | Purpose                                                                                                                        |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `SENTRY_DSN`                | Project DSN; keep it configurable through the deployment environment.                                                          |
+| `SENTRY_RELEASE`            | Optional release identifier such as a commit SHA — unlocks regression detection.                                               |
 | `SENTRY_TRACES_SAMPLE_RATE` | Trace sample rate, default `1`. Agents are low-throughput and every trace is interesting; lower it for high-volume plain HTTP. |
-| `PRODUCTION_BRANCH` | Your default branch's name, so it reports as environment `production` (see below). |
+| `PRODUCTION_BRANCH`         | Your default branch's name, so it reports as environment `production` (see below).                                             |
 
 ### 1. Initialize before anything else
 
@@ -46,7 +46,8 @@ Sentry.init({
   ],
   release: process.env.SENTRY_RELEASE,
   environment:
-    process.env.NEON_BRANCH && process.env.NEON_BRANCH !== process.env.PRODUCTION_BRANCH
+    process.env.NEON_BRANCH &&
+    process.env.NEON_BRANCH !== process.env.PRODUCTION_BRANCH
       ? process.env.NEON_BRANCH
       : "production",
 });
@@ -61,23 +62,13 @@ export { Sentry };
 // src/index.ts
 import "./instrument"; // MUST be the first import, before the framework/agent
 import { Sentry } from "./instrument";
+import { attachDatabasePool } from "@neon/functions";
 import { Hono } from "hono";
 import { Pool } from "pg";
 
-const PG_ADMIN_SHUTDOWN = "57P01";
-const IDLE_DISCONNECT_CODES = new Set(["ECONNRESET", "EPIPE", "ETIMEDOUT", PG_ADMIN_SHUTDOWN]);
-
-function isIdleDisconnect(err: Error): boolean {
-  const code = "code" in err && typeof err.code === "string" ? err.code : undefined;
-  return (
-    (code !== undefined && IDLE_DISCONNECT_CODES.has(code)) ||
-    err.message === "Connection terminated unexpectedly"
-  );
-}
-
 const pool = new Pool({ connectionString: process.env.DATABASE_URL, max: 5 });
-pool.on("error", (err) => {
-  if (!isIdleDisconnect(err)) Sentry.captureException(err);
+attachDatabasePool(pool, {
+  onUnexpectedError: (err) => Sentry.captureException(err),
 });
 
 // ... rest of the function
@@ -89,7 +80,7 @@ pool.on("error", (err) => {
 - **The two integrations:** `vercelAIIntegration({ force: true })` because `neon deploy` bundles your code, which defeats the integration's module detection; `httpIntegration({ disableIncomingRequestSpans: true })` because the request root span comes from the middleware in step 3 (the runtime's internal server would otherwise add a duplicate with an unhelpful name).
 - **Environment:** `NEON_BRANCH` is injected on every branch — including the default — and holds the branch **name** (e.g. `main`, `preview/add-auth`). Because it's always present, don't use it as a boolean flag; compare it against your default branch's name (passed in as `PRODUCTION_BRANCH`) so the default branch reads as `production` and other branches tag by name. Pass `SENTRY_ENVIRONMENT` explicitly per deploy to override.
 - **Flush on shutdown:** the runtime sends `SIGTERM`/`SIGINT` before evicting an idle isolate; Sentry buffers logs and batches spans, so flush or the tail gets dropped.
-- **Idle `pg` pool errors:** node-postgres emits idle-client failures as `error` on the pool. With no listener that is an `uncaughtException`: the isolate dies, and expected idle drops become fatal issues. Expected idle drops (`ECONNRESET` / `EPIPE` / `ETIMEDOUT`, Postgres `57P01`, pg's `Connection terminated unexpectedly`) stay silent; anything else is `Sentry.captureException`. Don't `pool.end()` on SIGINT — Neon's pooler reclaims those connections. See [Connecting to Postgres](../SKILL.md#connecting-to-postgres).
+- **Idle `pg` pool errors:** call `attachDatabasePool(pool)` (or pass `onUnexpectedError: (err) => Sentry.captureException(err)` on the first call). Don't `pool.end()` on SIGINT — Neon's pooler reclaims those connections. See [Connecting to Postgres](../SKILL.md#connecting-to-postgres).
 
 ### 2. Provide the DSN as a deploy-time secret
 
@@ -116,7 +107,10 @@ app.use("*", (c, next) =>
         op: "http.server",
         name: `${c.req.method} ${c.req.path}`,
         forceTransaction: true,
-        attributes: { "http.request.method": c.req.method, "url.path": c.req.path },
+        attributes: {
+          "http.request.method": c.req.method,
+          "url.path": c.req.path,
+        },
       },
       async (span) => {
         await next();
@@ -146,7 +140,7 @@ Long-running agent workloads — the case Neon Functions are built for — typic
 Split by whether someone needs to act:
 
 - **`Sentry.captureException` — terminal, needs attention.** The agent exhausted every fallback; an invariant broke. These become issues, group, and alert.
-- **`Sentry.logger.*` — recoverable or narrative.** A model attempt failed and the agent moved on; an input couldn't be fetched; a milestone was reached. Structured log records, searchable by attribute and attached to the request's trace — the story you read *after* an issue fires.
+- **`Sentry.logger.*` — recoverable or narrative.** A model attempt failed and the agent moved on; an input couldn't be fetched; a milestone was reached. Structured log records, searchable by attribute and attached to the request's trace — the story you read _after_ an issue fires.
 
 A representative agent that tries several models in order:
 
@@ -195,7 +189,9 @@ const result = streamText({
   tools,
   experimental_telemetry: { isEnabled: true },
   onError: ({ error }) => {
-    Sentry.captureException(error, { tags: { component: "agent", phase: "chat-stream" } });
+    Sentry.captureException(error, {
+      tags: { component: "agent", phase: "chat-stream" },
+    });
   },
 });
 ```
@@ -213,7 +209,9 @@ const stream = result.textStream
     }),
   )
   .pipeThrough(new TextEncoderStream());
-return new Response(stream, { headers: { "content-type": "text/plain; charset=utf-8" } });
+return new Response(stream, {
+  headers: { "content-type": "text/plain; charset=utf-8" },
+});
 ```
 
 (Once the runtime's `waitUntil` is no longer a preview stub, `waitUntil(Sentry.flush(2000))` is the cleaner way to express this.)

--- a/plugins/neon-postgres/skills/neon-functions/references/sentry.md
+++ b/plugins/neon-postgres/skills/neon-functions/references/sentry.md
@@ -62,7 +62,24 @@ export { Sentry };
 import "./instrument"; // MUST be the first import, before the framework/agent
 import { Sentry } from "./instrument";
 import { Hono } from "hono";
+import { Pool } from "pg";
 // ... rest of the function
+
+const PG_ADMIN_SHUTDOWN = "57P01";
+const IDLE_DISCONNECT_CODES = new Set(["ECONNRESET", "EPIPE", "ETIMEDOUT", PG_ADMIN_SHUTDOWN]);
+
+function isIdleDisconnect(err: Error): boolean {
+  const code = "code" in err && typeof err.code === "string" ? err.code : undefined;
+  return (
+    (code !== undefined && IDLE_DISCONNECT_CODES.has(code)) ||
+    err.message === "Connection terminated unexpectedly"
+  );
+}
+
+const pool = new Pool({ connectionString: process.env.DATABASE_URL, max: 5 });
+pool.on("error", (err) => {
+  if (!isIdleDisconnect(err)) Sentry.captureException(err);
+});
 ```
 
 - **Gate `enabled` on the DSN.** Local dev (`neon dev`) and any branch where you haven't configured the secret then become a no-op — no init, no noise — without changing code.
@@ -71,6 +88,7 @@ import { Hono } from "hono";
 - **The two integrations:** `vercelAIIntegration({ force: true })` because `neon deploy` bundles your code, which defeats the integration's module detection; `httpIntegration({ disableIncomingRequestSpans: true })` because the request root span comes from the middleware in step 3 (the runtime's internal server would otherwise add a duplicate with an unhelpful name).
 - **Environment:** `NEON_BRANCH` is injected on every branch — including the default — and holds the branch **name** (e.g. `main`, `preview/add-auth`). Because it's always present, don't use it as a boolean flag; compare it against your default branch's name (passed in as `PRODUCTION_BRANCH`) so the default branch reads as `production` and other branches tag by name. Pass `SENTRY_ENVIRONMENT` explicitly per deploy to override.
 - **Flush on shutdown:** the runtime sends `SIGTERM`/`SIGINT` before evicting an idle isolate; Sentry buffers logs and batches spans, so flush or the tail gets dropped.
+- **Idle `pg` pool errors:** node-postgres emits idle-client failures as `error` on the pool. With no listener that is an `uncaughtException` and the isolate exits before Sentry flushes. Expected idle drops (`ECONNRESET` / `EPIPE` / `ETIMEDOUT`, Postgres `57P01`, pg's `Connection terminated unexpectedly`) stay silent; anything else is `Sentry.captureException`. Don't `pool.end()` on SIGINT — Neon's pooler reclaims those connections. See [Connecting to Postgres](../SKILL.md#connecting-to-postgres).
 
 ### 2. Provide the DSN as a deploy-time secret
 

--- a/plugins/neon-postgres/skills/neon-functions/references/sentry.md
+++ b/plugins/neon-postgres/skills/neon-functions/references/sentry.md
@@ -63,7 +63,6 @@ import "./instrument"; // MUST be the first import, before the framework/agent
 import { Sentry } from "./instrument";
 import { Hono } from "hono";
 import { Pool } from "pg";
-// ... rest of the function
 
 const PG_ADMIN_SHUTDOWN = "57P01";
 const IDLE_DISCONNECT_CODES = new Set(["ECONNRESET", "EPIPE", "ETIMEDOUT", PG_ADMIN_SHUTDOWN]);
@@ -80,6 +79,8 @@ const pool = new Pool({ connectionString: process.env.DATABASE_URL, max: 5 });
 pool.on("error", (err) => {
   if (!isIdleDisconnect(err)) Sentry.captureException(err);
 });
+
+// ... rest of the function
 ```
 
 - **Gate `enabled` on the DSN.** Local dev (`neon dev`) and any branch where you haven't configured the secret then become a no-op — no init, no noise — without changing code.
@@ -88,7 +89,7 @@ pool.on("error", (err) => {
 - **The two integrations:** `vercelAIIntegration({ force: true })` because `neon deploy` bundles your code, which defeats the integration's module detection; `httpIntegration({ disableIncomingRequestSpans: true })` because the request root span comes from the middleware in step 3 (the runtime's internal server would otherwise add a duplicate with an unhelpful name).
 - **Environment:** `NEON_BRANCH` is injected on every branch — including the default — and holds the branch **name** (e.g. `main`, `preview/add-auth`). Because it's always present, don't use it as a boolean flag; compare it against your default branch's name (passed in as `PRODUCTION_BRANCH`) so the default branch reads as `production` and other branches tag by name. Pass `SENTRY_ENVIRONMENT` explicitly per deploy to override.
 - **Flush on shutdown:** the runtime sends `SIGTERM`/`SIGINT` before evicting an idle isolate; Sentry buffers logs and batches spans, so flush or the tail gets dropped.
-- **Idle `pg` pool errors:** node-postgres emits idle-client failures as `error` on the pool. With no listener that is an `uncaughtException` and the isolate exits before Sentry flushes. Expected idle drops (`ECONNRESET` / `EPIPE` / `ETIMEDOUT`, Postgres `57P01`, pg's `Connection terminated unexpectedly`) stay silent; anything else is `Sentry.captureException`. Don't `pool.end()` on SIGINT — Neon's pooler reclaims those connections. See [Connecting to Postgres](../SKILL.md#connecting-to-postgres).
+- **Idle `pg` pool errors:** node-postgres emits idle-client failures as `error` on the pool. With no listener that is an `uncaughtException`: the isolate dies, and expected idle drops become fatal issues. Expected idle drops (`ECONNRESET` / `EPIPE` / `ETIMEDOUT`, Postgres `57P01`, pg's `Connection terminated unexpectedly`) stay silent; anything else is `Sentry.captureException`. Don't `pool.end()` on SIGINT — Neon's pooler reclaims those connections. See [Connecting to Postgres](../SKILL.md#connecting-to-postgres).
 
 ### 2. Provide the DSN as a deploy-time secret
 

--- a/plugins/neon-postgres/skills/neon-functions/references/sse.md
+++ b/plugins/neon-postgres/skills/neon-functions/references/sse.md
@@ -78,9 +78,23 @@ The fan-out rule is identical to WebSockets ([Keeping clients in sync across iso
 ```typescript
 import { Pool, Client } from "pg";
 
+const PG_ADMIN_SHUTDOWN = "57P01";
+const IDLE_DISCONNECT_CODES = new Set(["ECONNRESET", "EPIPE", "ETIMEDOUT", PG_ADMIN_SHUTDOWN]);
+
+function isIdleDisconnect(err: Error): boolean {
+  const code = "code" in err && typeof err.code === "string" ? err.code : undefined;
+  return (
+    (code !== undefined && IDLE_DISCONNECT_CODES.has(code)) ||
+    err.message === "Connection terminated unexpectedly"
+  );
+}
+
 const encoder = new TextEncoder();
 const clients = new Set<ReadableStreamDefaultController<Uint8Array>>();
 const pool = new Pool({ connectionString: process.env.DATABASE_URL, max: 5 });
+pool.on("error", (err) => {
+  if (!isIdleDisconnect(err)) console.error(err);
+});
 const CHANNEL = "events";
 
 // One dedicated DIRECT connection per isolate to receive events (LISTEN needs a

--- a/plugins/neon-postgres/skills/neon-functions/references/sse.md
+++ b/plugins/neon-postgres/skills/neon-functions/references/sse.md
@@ -139,7 +139,7 @@ Send `data:` with no `event:` field to deliver the default `message` event, whic
 
 ```typescript
 const source = new EventSource(`${FUNCTION_URL}/events`); // GET only
-source.onmessage = (e) => console.log("update", e.data); // default "message" events
+source.onmessage = (e) => console.log("update", e.data);
 source.onerror = () => {
   /* EventSource auto-reconnects; nothing to do */
 };

--- a/plugins/neon-postgres/skills/neon-functions/references/sse.md
+++ b/plugins/neon-postgres/skills/neon-functions/references/sse.md
@@ -90,6 +90,7 @@ const CHANNEL = "events";
 
 // One dedicated DIRECT connection per isolate to receive events (LISTEN needs a
 // real session — use DATABASE_URL_UNPOOLED, not the pooled URL).
+// Don't call attachDatabasePool here: it would silence the idle drop that killed the feed.
 // An error listener keeps the isolate alive; the feed stays down until the isolate restarts.
 const listener = new Client({
   connectionString: process.env.DATABASE_URL_UNPOOLED,

--- a/plugins/neon-postgres/skills/neon-functions/references/sse.md
+++ b/plugins/neon-postgres/skills/neon-functions/references/sse.md
@@ -100,6 +100,9 @@ const CHANNEL = "events";
 // One dedicated DIRECT connection per isolate to receive events (LISTEN needs a
 // real session — use DATABASE_URL_UNPOOLED, not the pooled URL).
 const listener = new Client({ connectionString: process.env.DATABASE_URL_UNPOOLED });
+listener.on("error", (err) => {
+  if (!isIdleDisconnect(err)) console.error(err);
+});
 listener.connect().then(() => listener.query(`LISTEN ${CHANNEL}`));
 listener.on("notification", (msg) => {
   if (!msg.payload) return;

--- a/plugins/neon-postgres/skills/neon-functions/references/sse.md
+++ b/plugins/neon-postgres/skills/neon-functions/references/sse.md
@@ -99,6 +99,7 @@ const CHANNEL = "events";
 
 // One dedicated DIRECT connection per isolate to receive events (LISTEN needs a
 // real session — use DATABASE_URL_UNPOOLED, not the pooled URL).
+// An error listener keeps the isolate alive; the feed stays down until the isolate restarts.
 const listener = new Client({ connectionString: process.env.DATABASE_URL_UNPOOLED });
 listener.on("error", (err) => {
   if (!isIdleDisconnect(err)) console.error(err);

--- a/plugins/neon-postgres/skills/neon-functions/references/sse.md
+++ b/plugins/neon-postgres/skills/neon-functions/references/sse.md
@@ -64,7 +64,10 @@ app.get("/events", (c) => {
     },
   });
   return new Response(stream, {
-    headers: { "Content-Type": "text/event-stream", "Cache-Control": "no-cache, no-transform" },
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache, no-transform",
+    },
   });
 });
 
@@ -76,33 +79,23 @@ export default app;
 The fan-out rule is identical to WebSockets ([Keeping clients in sync across isolates](../SKILL.md#keeping-clients-in-sync-across-isolates-do-not-skip-this)): each isolate keeps its **own** set of open streams, so broadcasting in-process only reaches the clients on that isolate. Hold a `Set` of stream controllers and pick a strategy there — **poll Postgres** by default (keeps Scale to Zero), or `LISTEN`/`NOTIFY` (shown below) for lowest latency on always-on compute. Keep the source-of-truth state in Postgres — module state doesn't survive eviction.
 
 ```typescript
+import { attachDatabasePool } from "@neon/functions";
 import { Pool, Client } from "pg";
-
-const PG_ADMIN_SHUTDOWN = "57P01";
-const IDLE_DISCONNECT_CODES = new Set(["ECONNRESET", "EPIPE", "ETIMEDOUT", PG_ADMIN_SHUTDOWN]);
-
-function isIdleDisconnect(err: Error): boolean {
-  const code = "code" in err && typeof err.code === "string" ? err.code : undefined;
-  return (
-    (code !== undefined && IDLE_DISCONNECT_CODES.has(code)) ||
-    err.message === "Connection terminated unexpectedly"
-  );
-}
 
 const encoder = new TextEncoder();
 const clients = new Set<ReadableStreamDefaultController<Uint8Array>>();
 const pool = new Pool({ connectionString: process.env.DATABASE_URL, max: 5 });
-pool.on("error", (err) => {
-  if (!isIdleDisconnect(err)) console.error(err);
-});
+attachDatabasePool(pool);
 const CHANNEL = "events";
 
 // One dedicated DIRECT connection per isolate to receive events (LISTEN needs a
 // real session — use DATABASE_URL_UNPOOLED, not the pooled URL).
 // An error listener keeps the isolate alive; the feed stays down until the isolate restarts.
-const listener = new Client({ connectionString: process.env.DATABASE_URL_UNPOOLED });
+const listener = new Client({
+  connectionString: process.env.DATABASE_URL_UNPOOLED,
+});
 listener.on("error", (err) => {
-  if (!isIdleDisconnect(err)) console.error(err);
+  console.error(err);
 });
 listener.connect().then(() => listener.query(`LISTEN ${CHANNEL}`));
 listener.on("notification", (msg) => {
@@ -119,7 +112,10 @@ listener.on("notification", (msg) => {
 
 // Anywhere you mutate state, NOTIFY so every isolate pushes to its own streams.
 function publish(payload: unknown) {
-  return pool.query("SELECT pg_notify($1, $2)", [CHANNEL, JSON.stringify(payload)]);
+  return pool.query("SELECT pg_notify($1, $2)", [
+    CHANNEL,
+    JSON.stringify(payload),
+  ]);
 }
 ```
 
@@ -143,8 +139,10 @@ Send `data:` with no `event:` field to deliver the default `message` event, whic
 
 ```typescript
 const source = new EventSource(`${FUNCTION_URL}/events`); // GET only
-source.onmessage = (e) => console.log("update", e.data);  // default "message" events
-source.onerror = () => {/* EventSource auto-reconnects; nothing to do */};
+source.onmessage = (e) => console.log("update", e.data); // default "message" events
+source.onerror = () => {
+  /* EventSource auto-reconnects; nothing to do */
+};
 // source.close() to stop.
 ```
 

--- a/skills/neon-functions/SKILL.md
+++ b/skills/neon-functions/SKILL.md
@@ -215,7 +215,7 @@ attachDatabasePool(pool);
 const db = drizzle(pool);
 ```
 
-node-postgres emits idle-client failures as `error` on the pool. With no listener that is an `uncaughtException` and Node exits the isolate. Call `attachDatabasePool(pool)` once after `new Pool`. Expected idle disconnects (`ECONNRESET`, `EPIPE`, `ETIMEDOUT`, Postgres `57P01`, node-postgres's `Connection terminated unexpectedly`) are silent. Anything else is `console.error`, or `onUnexpectedError` if you pass it on the first call. The first call wins; a later call that passes `onUnexpectedError` is ignored and warns. This does not close the pool.
+node-postgres emits idle-client failures as `error` on the pool. With no listener that is an `uncaughtException` and Node exits the isolate. Call `attachDatabasePool(pool)` once after `new Pool`. Requires `@neon/functions` ≥ 0.8.0. Expected idle disconnects (`ECONNRESET`, `EPIPE`, `ETIMEDOUT`, Postgres `57P01`, node-postgres's `Connection terminated unexpectedly`) are silent. Anything else is `console.error`, or `onUnexpectedError` if you pass it on the first call. The first call wins; a later call that passes `onUnexpectedError` is ignored and warns. This does not close the pool.
 
 **Pooling is recommended because an isolate is reused across many requests** (and several requests can be in flight on the same isolate at once — see [Timeouts and Runtime Limits](#timeouts-and-runtime-limits)). A module-scope pool is opened once on cold start and then shared by every subsequent request that isolate serves, so you amortize connection setup instead of paying it on every request and you avoid exhausting Postgres connections under load.
 
@@ -483,9 +483,10 @@ async function connect() {
   const token = await getToken(); // re-mint each attempt; short-lived
   const ws = new WebSocket(`${WS_URL}?token=${encodeURIComponent(token)}`);
   ws.onopen = () => {
-    retry = 0;
+    retry = 0; // reset backoff on success
   };
   ws.onmessage = (e) => {
+    /* apply the event */
   };
   ws.onclose = () => {
     if (!closed)

--- a/skills/neon-functions/SKILL.md
+++ b/skills/neon-functions/SKILL.md
@@ -242,7 +242,7 @@ pool.on("error", (err) => {
 const db = drizzle(pool);
 ```
 
-node-postgres emits idle-client failures as `error` on the pool. With no listener that is an `uncaughtException` and Node exits the isolate. Expected idle drops — TCP reset (`ECONNRESET` / `EPIPE` / `ETIMEDOUT`), Postgres admin shutdown (`57P01`, compute scale-to-zero), and pg's `Connection terminated unexpectedly` — are silent. Anything else is logged.
+node-postgres emits idle-client failures as `error` on the pool. With no listener that is an `uncaughtException` and Node exits the isolate. pg's own idle timer (`idleTimeoutMillis`, default 10s) closes idle clients cleanly and does not emit `error`. This listener is for the server or an intermediary closing a client that is still in the pool. Expected idle drops — TCP reset (`ECONNRESET` / `EPIPE` / `ETIMEDOUT`), Postgres admin shutdown (`57P01`, compute scale-to-zero), and pg's `Connection terminated unexpectedly` — are silent. Anything else is logged.
 
 **Pooling is recommended because an isolate is reused across many requests** (and several requests can be in flight on the same isolate at once — see [Timeouts and Runtime Limits](#timeouts-and-runtime-limits)). A module-scope pool is opened once on cold start and then shared by every subsequent request that isolate serves, so you amortize connection setup instead of paying it on every request and you avoid exhausting Postgres connections under load.
 
@@ -470,6 +470,9 @@ const CHANNEL = "chat_events";
 // One dedicated DIRECT connection per isolate, just to receive events.
 // Use DATABASE_URL_UNPOOLED — LISTEN needs a real session, not a pooled one.
 const listener = new Client({ connectionString: process.env.DATABASE_URL_UNPOOLED });
+listener.on("error", (err) => {
+  if (!isIdleDisconnect(err)) console.error(err);
+});
 listener.connect().then(() => listener.query(`LISTEN ${CHANNEL}`));
 listener.on("notification", (msg) => {
   if (!msg.payload) return;

--- a/skills/neon-functions/SKILL.md
+++ b/skills/neon-functions/SKILL.md
@@ -100,8 +100,22 @@ import { parseEnv } from "@neon/env";
 import config from "../neon";
 import { todos } from "./db/schema";
 
+const PG_ADMIN_SHUTDOWN = "57P01";
+const IDLE_DISCONNECT_CODES = new Set(["ECONNRESET", "EPIPE", "ETIMEDOUT", PG_ADMIN_SHUTDOWN]);
+
+function isIdleDisconnect(err: Error): boolean {
+  const code = "code" in err && typeof err.code === "string" ? err.code : undefined;
+  return (
+    (code !== undefined && IDLE_DISCONNECT_CODES.has(code)) ||
+    err.message === "Connection terminated unexpectedly"
+  );
+}
+
 const env = parseEnv(config);
 const pool = new Pool({ connectionString: env.postgres.databaseUrl, max: 5 });
+pool.on("error", (err) => {
+  if (!isIdleDisconnect(err)) console.error(err);
+});
 const db = drizzle(pool);
 
 const app = new Hono();
@@ -116,13 +130,16 @@ app.get("/todos", async (c) => c.json(await db.select().from(todos)));
 export default app;
 ```
 
-Create the `pg` pool at module scope (reused across requests on the same isolate) and keep `max` small (e.g. 5), since each isolate keeps its own pool.
+Create the `pg` pool at module scope (reused across requests on the same isolate) and keep `max` small (e.g. 5), since each isolate keeps its own pool. Attach a pool `error` listener so an idle disconnect is not an `uncaughtException` — see [Connecting to Postgres](#connecting-to-postgres).
 
 `parseEnv(config)` requires _every_ variable the config implies. A function that only talks to Postgres over the pooled URL can scope it to just that key — `parseEnv` then validates and returns only what you asked for (the keys autocomplete from your `neon.ts`):
 
 ```typescript
 const { postgres } = parseEnv(config, ["DATABASE_URL"]); // not the unpooled URL, auth, etc.
 const pool = new Pool({ connectionString: postgres.databaseUrl, max: 5 });
+pool.on("error", (err) => {
+  if (!isIdleDisconnect(err)) console.error(err);
+});
 ```
 
 ## Develop Locally and Deploy
@@ -206,10 +223,26 @@ Create the connection pool **once at module scope** and reuse it across requests
 import { drizzle } from "drizzle-orm/node-postgres";
 import { Pool } from "pg";
 
+const PG_ADMIN_SHUTDOWN = "57P01";
+const IDLE_DISCONNECT_CODES = new Set(["ECONNRESET", "EPIPE", "ETIMEDOUT", PG_ADMIN_SHUTDOWN]);
+
+function isIdleDisconnect(err: Error): boolean {
+  const code = "code" in err && typeof err.code === "string" ? err.code : undefined;
+  return (
+    (code !== undefined && IDLE_DISCONNECT_CODES.has(code)) ||
+    err.message === "Connection terminated unexpectedly"
+  );
+}
+
 // Created once per isolate; reused by every request that isolate handles.
 const pool = new Pool({ connectionString: process.env.DATABASE_URL, max: 5 });
+pool.on("error", (err) => {
+  if (!isIdleDisconnect(err)) console.error(err);
+});
 const db = drizzle(pool);
 ```
+
+node-postgres emits idle-client failures as `error` on the pool. With no listener that is an `uncaughtException` and Node exits the isolate. Expected idle drops — TCP reset (`ECONNRESET` / `EPIPE` / `ETIMEDOUT`), Postgres admin shutdown (`57P01`, compute scale-to-zero), and pg's `Connection terminated unexpectedly` — are silent. Anything else is logged.
 
 **Pooling is recommended because an isolate is reused across many requests** (and several requests can be in flight on the same isolate at once — see [Timeouts and Runtime Limits](#timeouts-and-runtime-limits)). A module-scope pool is opened once on cold start and then shared by every subsequent request that isolate serves, so you amortize connection setup instead of paying it on every request and you avoid exhausting Postgres connections under load.
 
@@ -418,6 +451,9 @@ poller.unref?.();
 import { Pool, Client } from "pg";
 
 const pool = new Pool({ connectionString: process.env.DATABASE_URL, max: 5 });
+pool.on("error", (err) => {
+  if (!isIdleDisconnect(err)) console.error(err);
+});
 const CHANNEL = "chat_events";
 
 // One dedicated DIRECT connection per isolate, just to receive events.

--- a/skills/neon-functions/SKILL.md
+++ b/skills/neon-functions/SKILL.md
@@ -469,6 +469,7 @@ const CHANNEL = "chat_events";
 
 // One dedicated DIRECT connection per isolate, just to receive events.
 // Use DATABASE_URL_UNPOOLED — LISTEN needs a real session, not a pooled one.
+// An error listener keeps the isolate alive; the feed stays down until the isolate restarts.
 const listener = new Client({ connectionString: process.env.DATABASE_URL_UNPOOLED });
 listener.on("error", (err) => {
   if (!isIdleDisconnect(err)) console.error(err);

--- a/skills/neon-functions/SKILL.md
+++ b/skills/neon-functions/SKILL.md
@@ -450,6 +450,17 @@ poller.unref?.();
 ```typescript
 import { Pool, Client } from "pg";
 
+const PG_ADMIN_SHUTDOWN = "57P01";
+const IDLE_DISCONNECT_CODES = new Set(["ECONNRESET", "EPIPE", "ETIMEDOUT", PG_ADMIN_SHUTDOWN]);
+
+function isIdleDisconnect(err: Error): boolean {
+  const code = "code" in err && typeof err.code === "string" ? err.code : undefined;
+  return (
+    (code !== undefined && IDLE_DISCONNECT_CODES.has(code)) ||
+    err.message === "Connection terminated unexpectedly"
+  );
+}
+
 const pool = new Pool({ connectionString: process.env.DATABASE_URL, max: 5 });
 pool.on("error", (err) => {
   if (!isIdleDisconnect(err)) console.error(err);

--- a/skills/neon-functions/SKILL.md
+++ b/skills/neon-functions/SKILL.md
@@ -97,25 +97,13 @@ import { Hono } from "hono";
 import { drizzle } from "drizzle-orm/node-postgres";
 import { Pool } from "pg";
 import { parseEnv } from "@neon/env";
+import { attachDatabasePool } from "@neon/functions";
 import config from "../neon";
 import { todos } from "./db/schema";
 
-const PG_ADMIN_SHUTDOWN = "57P01";
-const IDLE_DISCONNECT_CODES = new Set(["ECONNRESET", "EPIPE", "ETIMEDOUT", PG_ADMIN_SHUTDOWN]);
-
-function isIdleDisconnect(err: Error): boolean {
-  const code = "code" in err && typeof err.code === "string" ? err.code : undefined;
-  return (
-    (code !== undefined && IDLE_DISCONNECT_CODES.has(code)) ||
-    err.message === "Connection terminated unexpectedly"
-  );
-}
-
 const env = parseEnv(config);
 const pool = new Pool({ connectionString: env.postgres.databaseUrl, max: 5 });
-pool.on("error", (err) => {
-  if (!isIdleDisconnect(err)) console.error(err);
-});
+attachDatabasePool(pool);
 const db = drizzle(pool);
 
 const app = new Hono();
@@ -130,16 +118,14 @@ app.get("/todos", async (c) => c.json(await db.select().from(todos)));
 export default app;
 ```
 
-Create the `pg` pool at module scope (reused across requests on the same isolate) and keep `max` small (e.g. 5), since each isolate keeps its own pool. Attach a pool `error` listener so an idle disconnect is not an `uncaughtException` — see [Connecting to Postgres](#connecting-to-postgres).
+Create the `pg` pool at module scope (reused across requests on the same isolate) and keep `max` small (e.g. 5), since each isolate keeps its own pool. Call `attachDatabasePool(pool)` so an idle disconnect is not an `uncaughtException` — see [Connecting to Postgres](#connecting-to-postgres).
 
 `parseEnv(config)` requires _every_ variable the config implies. A function that only talks to Postgres over the pooled URL can scope it to just that key — `parseEnv` then validates and returns only what you asked for (the keys autocomplete from your `neon.ts`):
 
 ```typescript
 const { postgres } = parseEnv(config, ["DATABASE_URL"]); // not the unpooled URL, auth, etc.
 const pool = new Pool({ connectionString: postgres.databaseUrl, max: 5 });
-pool.on("error", (err) => {
-  if (!isIdleDisconnect(err)) console.error(err);
-});
+attachDatabasePool(pool);
 ```
 
 ## Develop Locally and Deploy
@@ -182,13 +168,13 @@ export default defineConfig({
 
 Neon injects branch-scoped connection strings and service URLs at runtime — you don't declare these or pass them at deploy time:
 
-| Variable                | Notes                                                                                    |
-| ----------------------- | ---------------------------------------------------------------------------------------- |
+| Variable                | Notes                                                                                              |
+| ----------------------- | -------------------------------------------------------------------------------------------------- |
 | `NEON_BRANCH`           | The branch **name** (e.g. `main`, `preview/foo`). Injected on every branch, including the default. |
-| `DATABASE_URL`          | Pooled connection string. Use for most queries. Present only if the branch has Postgres. |
-| `DATABASE_URL_UNPOOLED` | Direct connection. Use for migrations, `LISTEN`/`NOTIFY`, multi-round-trip transactions. |
-| `NEON_AUTH_BASE_URL`    | Present when Neon Auth is enabled on the branch.                                         |
-| `NEON_DATA_API_URL`     | Present when the Data API is enabled on the branch.                                      |
+| `DATABASE_URL`          | Pooled connection string. Use for most queries. Present only if the branch has Postgres.           |
+| `DATABASE_URL_UNPOOLED` | Direct connection. Use for migrations, `LISTEN`/`NOTIFY`, multi-round-trip transactions.           |
+| `NEON_AUTH_BASE_URL`    | Present when Neon Auth is enabled on the branch.                                                   |
+| `NEON_DATA_API_URL`     | Present when the Data API is enabled on the branch.                                                |
 
 Object storage (`AWS_*`) and AI Gateway (`NEON_AI_GATEWAY_*`) vars are also injected when those services are declared — see the `neon-object-storage` and `neon-ai-gateway` skills.
 
@@ -220,29 +206,16 @@ When the branch has Postgres, Neon **injects the connection strings at runtime**
 Create the connection pool **once at module scope** and reuse it across requests — don't open a connection per request:
 
 ```typescript
+import { attachDatabasePool } from "@neon/functions";
 import { drizzle } from "drizzle-orm/node-postgres";
 import { Pool } from "pg";
 
-const PG_ADMIN_SHUTDOWN = "57P01";
-const IDLE_DISCONNECT_CODES = new Set(["ECONNRESET", "EPIPE", "ETIMEDOUT", PG_ADMIN_SHUTDOWN]);
-
-function isIdleDisconnect(err: Error): boolean {
-  const code = "code" in err && typeof err.code === "string" ? err.code : undefined;
-  return (
-    (code !== undefined && IDLE_DISCONNECT_CODES.has(code)) ||
-    err.message === "Connection terminated unexpectedly"
-  );
-}
-
-// Created once per isolate; reused by every request that isolate handles.
 const pool = new Pool({ connectionString: process.env.DATABASE_URL, max: 5 });
-pool.on("error", (err) => {
-  if (!isIdleDisconnect(err)) console.error(err);
-});
+attachDatabasePool(pool);
 const db = drizzle(pool);
 ```
 
-node-postgres emits idle-client failures as `error` on the pool. With no listener that is an `uncaughtException` and Node exits the isolate. pg's own idle timer (`idleTimeoutMillis`, default 10s) closes idle clients cleanly and does not emit `error`. This listener is for the server or an intermediary closing a client that is still in the pool. Expected idle drops — TCP reset (`ECONNRESET` / `EPIPE` / `ETIMEDOUT`), Postgres admin shutdown (`57P01`, compute scale-to-zero), and pg's `Connection terminated unexpectedly` — are silent. Anything else is logged.
+node-postgres emits idle-client failures as `error` on the pool. With no listener that is an `uncaughtException` and Node exits the isolate. Call `attachDatabasePool(pool)` once after `new Pool`. Expected idle disconnects (`ECONNRESET`, `EPIPE`, `ETIMEDOUT`, Postgres `57P01`, node-postgres's `Connection terminated unexpectedly`) are silent. Anything else is `console.error`, or `onUnexpectedError` if you pass it on the first call. The first call wins; a later call that passes `onUnexpectedError` is ignored and warns. This does not close the pool.
 
 **Pooling is recommended because an isolate is reused across many requests** (and several requests can be in flight on the same isolate at once — see [Timeouts and Runtime Limits](#timeouts-and-runtime-limits)). A module-scope pool is opened once on cold start and then shared by every subsequent request that isolate serves, so you amortize connection setup instead of paying it on every request and you avoid exhausting Postgres connections under load.
 
@@ -284,15 +257,21 @@ Browser ──▶ your app backend ──▶ Neon Function                      
 // src/index.ts — verify the caller before doing any work
 import { createRemoteJWKSet, jwtVerify } from "jose";
 
-const jwks = createRemoteJWKSet(new URL(`${process.env.AUTH_BASE_URL}/api/auth/jwks`));
+const jwks = createRemoteJWKSet(
+  new URL(`${process.env.AUTH_BASE_URL}/api/auth/jwks`),
+);
 
 export default {
   async fetch(request: Request) {
-    if (request.method === "OPTIONS") return new Response(null, { status: 204, headers: cors(request) });
+    if (request.method === "OPTIONS")
+      return new Response(null, { status: 204, headers: cors(request) });
 
     const auth = request.headers.get("authorization");
     if (!auth?.toLowerCase().startsWith("bearer ")) {
-      return new Response("Unauthorized", { status: 401, headers: cors(request) });
+      return new Response("Unauthorized", {
+        status: 401,
+        headers: cors(request),
+      });
     }
     try {
       const { payload } = await jwtVerify(auth.slice(7), jwks, {
@@ -302,7 +281,10 @@ export default {
       const userId = payload.sub; // scope the agent to this user
       // ... run the agent, return result.toUIMessageStreamResponse({ headers: cors(request) })
     } catch {
-      return new Response("Unauthorized", { status: 401, headers: cors(request) });
+      return new Response("Unauthorized", {
+        status: 401,
+        headers: cors(request),
+      });
     }
   },
 };
@@ -389,7 +371,9 @@ app.get("/ws", async (c) => {
 
   const { socket, response } = upgradeWebSocket(c.req.raw);
   socket.addEventListener("open", () => socket.send("welcome"));
-  socket.addEventListener("message", (event) => socket.send(`echo: ${event.data}`));
+  socket.addEventListener("message", (event) =>
+    socket.send(`echo: ${event.data}`),
+  );
   return response;
 });
 
@@ -448,31 +432,21 @@ poller.unref?.();
 **2. `LISTEN`/`NOTIFY` — lowest latency, but requires disabling Scale to Zero.** Each isolate `LISTEN`s on a channel over a dedicated **unpooled** connection; broadcasting is `NOTIFY`, so every isolate (including the sender's) re-pushes to its sockets. Near-instant — but the listener holds an idle connection that **does not count as active**, so [Scale to Zero](https://neon.com/docs/introduction/scale-to-zero) suspends the compute and drops it, silently killing the feed. Only use it on an **always-on** compute (Scale to Zero disabled — a paid-plan setting).
 
 ```typescript
+import { attachDatabasePool } from "@neon/functions";
 import { Pool, Client } from "pg";
 
-const PG_ADMIN_SHUTDOWN = "57P01";
-const IDLE_DISCONNECT_CODES = new Set(["ECONNRESET", "EPIPE", "ETIMEDOUT", PG_ADMIN_SHUTDOWN]);
-
-function isIdleDisconnect(err: Error): boolean {
-  const code = "code" in err && typeof err.code === "string" ? err.code : undefined;
-  return (
-    (code !== undefined && IDLE_DISCONNECT_CODES.has(code)) ||
-    err.message === "Connection terminated unexpectedly"
-  );
-}
-
 const pool = new Pool({ connectionString: process.env.DATABASE_URL, max: 5 });
-pool.on("error", (err) => {
-  if (!isIdleDisconnect(err)) console.error(err);
-});
+attachDatabasePool(pool);
 const CHANNEL = "chat_events";
 
 // One dedicated DIRECT connection per isolate, just to receive events.
 // Use DATABASE_URL_UNPOOLED — LISTEN needs a real session, not a pooled one.
 // An error listener keeps the isolate alive; the feed stays down until the isolate restarts.
-const listener = new Client({ connectionString: process.env.DATABASE_URL_UNPOOLED });
+const listener = new Client({
+  connectionString: process.env.DATABASE_URL_UNPOOLED,
+});
 listener.on("error", (err) => {
-  if (!isIdleDisconnect(err)) console.error(err);
+  console.error(err);
 });
 listener.connect().then(() => listener.query(`LISTEN ${CHANNEL}`));
 listener.on("notification", (msg) => {
@@ -484,7 +458,10 @@ listener.on("notification", (msg) => {
 
 // Broadcast by NOTIFYing through the pool — every isolate's listener fires.
 function broadcast(event: unknown) {
-  return pool.query("SELECT pg_notify($1, $2)", [CHANNEL, JSON.stringify(event)]);
+  return pool.query("SELECT pg_notify($1, $2)", [
+    CHANNEL,
+    JSON.stringify(event),
+  ]);
 }
 ```
 
@@ -497,18 +474,25 @@ function broadcast(event: unknown) {
 Idle functions are evicted (and isolates restart for operational reasons), so a client's socket **will** drop — treat reconnection as normal, not exceptional. Reconnect with exponential backoff, capped, and **re-mint a fresh token on every attempt** (tokens are short-lived, so a stale one fails the `upgrade` auth check):
 
 ```typescript
-let closed = false, retry = 0, timer: ReturnType<typeof setTimeout>;
+let closed = false,
+  retry = 0,
+  timer: ReturnType<typeof setTimeout>;
 
 async function connect() {
   if (closed) return;
   const token = await getToken(); // re-mint each attempt; short-lived
   const ws = new WebSocket(`${WS_URL}?token=${encodeURIComponent(token)}`);
-  ws.onopen = () => { retry = 0; };          // reset backoff on success
-  ws.onmessage = (e) => { /* apply the event */ };
-  ws.onclose = () => {
-    if (!closed) timer = setTimeout(connect, Math.min(1000 * 2 ** retry++, 15000));
+  ws.onopen = () => {
+    retry = 0;
+  }; // reset backoff on success
+  ws.onmessage = (e) => {
+    /* apply the event */
   };
-  ws.onerror = () => ws.close();             // let onclose drive the retry
+  ws.onclose = () => {
+    if (!closed)
+      timer = setTimeout(connect, Math.min(1000 * 2 ** retry++, 15000));
+  };
+  ws.onerror = () => ws.close(); // let onclose drive the retry
 }
 connect();
 ```
@@ -528,11 +512,19 @@ export default {
       new ReadableStream<Uint8Array>({
         start(controller) {
           controller.enqueue(encoder.encode("data: hello\n\n"));
-          const t = setInterval(() => controller.enqueue(encoder.encode(": ping\n\n")), 25_000);
+          const t = setInterval(
+            () => controller.enqueue(encoder.encode(": ping\n\n")),
+            25_000,
+          );
           return () => clearInterval(t); // fires when the client disconnects
         },
       }),
-      { headers: { "Content-Type": "text/event-stream", "Cache-Control": "no-cache, no-transform" } },
+      {
+        headers: {
+          "Content-Type": "text/event-stream",
+          "Cache-Control": "no-cache, no-transform",
+        },
+      },
     ),
 };
 ```

--- a/skills/neon-functions/SKILL.md
+++ b/skills/neon-functions/SKILL.md
@@ -484,9 +484,8 @@ async function connect() {
   const ws = new WebSocket(`${WS_URL}?token=${encodeURIComponent(token)}`);
   ws.onopen = () => {
     retry = 0;
-  }; // reset backoff on success
+  };
   ws.onmessage = (e) => {
-    /* apply the event */
   };
   ws.onclose = () => {
     if (!closed)

--- a/skills/neon-functions/SKILL.md
+++ b/skills/neon-functions/SKILL.md
@@ -441,6 +441,7 @@ const CHANNEL = "chat_events";
 
 // One dedicated DIRECT connection per isolate, just to receive events.
 // Use DATABASE_URL_UNPOOLED — LISTEN needs a real session, not a pooled one.
+// Don't call attachDatabasePool here: it would silence the idle drop that killed the feed.
 // An error listener keeps the isolate alive; the feed stays down until the isolate restarts.
 const listener = new Client({
   connectionString: process.env.DATABASE_URL_UNPOOLED,

--- a/skills/neon-functions/references/ai-sdk.md
+++ b/skills/neon-functions/references/ai-sdk.md
@@ -32,27 +32,15 @@ The function's default export is a web-standard `{ fetch }` handler. The `@neon/
 ```typescript
 // src/index.ts
 import { neon } from "@neon/ai-sdk-provider";
+import { attachDatabasePool } from "@neon/functions";
 import { streamText, tool, stepCountIs, type ModelMessage } from "ai";
 import { z } from "zod";
 import { drizzle } from "drizzle-orm/node-postgres";
 import { Pool } from "pg";
 import { todos } from "./db/schema";
 
-const PG_ADMIN_SHUTDOWN = "57P01";
-const IDLE_DISCONNECT_CODES = new Set(["ECONNRESET", "EPIPE", "ETIMEDOUT", PG_ADMIN_SHUTDOWN]);
-
-function isIdleDisconnect(err: Error): boolean {
-  const code = "code" in err && typeof err.code === "string" ? err.code : undefined;
-  return (
-    (code !== undefined && IDLE_DISCONNECT_CODES.has(code)) ||
-    err.message === "Connection terminated unexpectedly"
-  );
-}
-
 const pool = new Pool({ connectionString: process.env.DATABASE_URL, max: 5 });
-pool.on("error", (err) => {
-  if (!isIdleDisconnect(err)) console.error(err);
-});
+attachDatabasePool(pool);
 const db = drizzle(pool);
 
 export default {
@@ -82,7 +70,8 @@ export default {
     });
 
     return result.toUIMessageStreamResponse({
-      onError: (error) => (error instanceof Error ? error.message : String(error)),
+      onError: (error) =>
+        error instanceof Error ? error.message : String(error),
     });
   },
 };
@@ -105,7 +94,8 @@ const files = new Files({ adapter: neonFiles({ bucket: "images" }) });
 
 const result = streamText({
   model: neon("gpt-5-mini"),
-  system: "Use image_generation when the user asks for a picture, then describe it.",
+  system:
+    "Use image_generation when the user asks for a picture, then describe it.",
   messages,
   tools: {
     image_generation: neon.tools.imageGeneration({
@@ -120,7 +110,9 @@ const result = streamText({
       const base64 = imageResultBase64(tr.output);
       if (!base64) continue;
       const key = `generated/${randomUUID()}.jpg`;
-      await files.upload(key, Buffer.from(base64, "base64"), { contentType: "image/jpeg" });
+      await files.upload(key, Buffer.from(base64, "base64"), {
+        contentType: "image/jpeg",
+      });
       // …insert a row keyed by `key` into Postgres; serve later via files.url(key)
     }
   },

--- a/skills/neon-functions/references/ai-sdk.md
+++ b/skills/neon-functions/references/ai-sdk.md
@@ -38,7 +38,21 @@ import { drizzle } from "drizzle-orm/node-postgres";
 import { Pool } from "pg";
 import { todos } from "./db/schema";
 
+const PG_ADMIN_SHUTDOWN = "57P01";
+const IDLE_DISCONNECT_CODES = new Set(["ECONNRESET", "EPIPE", "ETIMEDOUT", PG_ADMIN_SHUTDOWN]);
+
+function isIdleDisconnect(err: Error): boolean {
+  const code = "code" in err && typeof err.code === "string" ? err.code : undefined;
+  return (
+    (code !== undefined && IDLE_DISCONNECT_CODES.has(code)) ||
+    err.message === "Connection terminated unexpectedly"
+  );
+}
+
 const pool = new Pool({ connectionString: process.env.DATABASE_URL, max: 5 });
+pool.on("error", (err) => {
+  if (!isIdleDisconnect(err)) console.error(err);
+});
 const db = drizzle(pool);
 
 export default {

--- a/skills/neon-functions/references/mcp.md
+++ b/skills/neon-functions/references/mcp.md
@@ -133,7 +133,7 @@ Either way it's one check at the top of the `/mcp` route — reject anything tha
 app.all("/mcp", async (c) => {
   const auth = c.req.header("authorization");
   if (!(await isValidApiKey(auth)))
-    return c.json({ error: "unauthorized" }, 401); // your check
+    return c.json({ error: "unauthorized" }, 401);
   if (!mcpServer.isConnected()) await mcpServer.connect(transport);
   return transport.handleRequest(c);
 });

--- a/skills/neon-functions/references/mcp.md
+++ b/skills/neon-functions/references/mcp.md
@@ -19,8 +19,22 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StreamableHTTPTransport } from "@hono/mcp";
 import { contacts } from "./db/schema";
 
+const PG_ADMIN_SHUTDOWN = "57P01";
+const IDLE_DISCONNECT_CODES = new Set(["ECONNRESET", "EPIPE", "ETIMEDOUT", PG_ADMIN_SHUTDOWN]);
+
+function isIdleDisconnect(err: Error): boolean {
+  const code = "code" in err && typeof err.code === "string" ? err.code : undefined;
+  return (
+    (code !== undefined && IDLE_DISCONNECT_CODES.has(code)) ||
+    err.message === "Connection terminated unexpectedly"
+  );
+}
+
 // One pool per isolate, reused across requests.
 const pool = new Pool({ connectionString: process.env.DATABASE_URL, max: 5 });
+pool.on("error", (err) => {
+  if (!isIdleDisconnect(err)) console.error(err);
+});
 const db = drizzle(pool);
 
 const mcpServer = new McpServer({ name: "contacts", version: "1.0.0" });

--- a/skills/neon-functions/references/mcp.md
+++ b/skills/neon-functions/references/mcp.md
@@ -17,24 +17,11 @@ import { eq } from "drizzle-orm";
 import { z } from "zod";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StreamableHTTPTransport } from "@hono/mcp";
+import { attachDatabasePool } from "@neon/functions";
 import { contacts } from "./db/schema";
 
-const PG_ADMIN_SHUTDOWN = "57P01";
-const IDLE_DISCONNECT_CODES = new Set(["ECONNRESET", "EPIPE", "ETIMEDOUT", PG_ADMIN_SHUTDOWN]);
-
-function isIdleDisconnect(err: Error): boolean {
-  const code = "code" in err && typeof err.code === "string" ? err.code : undefined;
-  return (
-    (code !== undefined && IDLE_DISCONNECT_CODES.has(code)) ||
-    err.message === "Connection terminated unexpectedly"
-  );
-}
-
-// One pool per isolate, reused across requests.
 const pool = new Pool({ connectionString: process.env.DATABASE_URL, max: 5 });
-pool.on("error", (err) => {
-  if (!isIdleDisconnect(err)) console.error(err);
-});
+attachDatabasePool(pool);
 const db = drizzle(pool);
 
 const mcpServer = new McpServer({ name: "contacts", version: "1.0.0" });
@@ -66,8 +53,15 @@ mcpServer.registerTool(
     inputSchema: { id: z.number().int().positive() },
   },
   async ({ id }) => {
-    const [row] = await db.delete(contacts).where(eq(contacts.id, id)).returning();
-    return { content: [{ type: "text", text: JSON.stringify(row ?? { error: "not found" }) }] };
+    const [row] = await db
+      .delete(contacts)
+      .where(eq(contacts.id, id))
+      .returning();
+    return {
+      content: [
+        { type: "text", text: JSON.stringify(row ?? { error: "not found" }) },
+      ],
+    };
   },
 );
 
@@ -138,7 +132,8 @@ Either way it's one check at the top of the `/mcp` route — reject anything tha
 ```typescript
 app.all("/mcp", async (c) => {
   const auth = c.req.header("authorization");
-  if (!(await isValidApiKey(auth))) return c.json({ error: "unauthorized" }, 401); // your check
+  if (!(await isValidApiKey(auth)))
+    return c.json({ error: "unauthorized" }, 401); // your check
   if (!mcpServer.isConnected()) await mcpServer.connect(transport);
   return transport.handleRequest(c);
 });

--- a/skills/neon-functions/references/sentry.md
+++ b/skills/neon-functions/references/sentry.md
@@ -10,7 +10,7 @@ Because the runtime is a normal Node process, use the Node SDK `@sentry/node` �
 
 Sentry has distinct signals, and picking the right one is the main instrumentation decision:
 
-1. **Errors** — unhandled route errors and failures your code can't recover from. Each becomes a grouped, alertable *issue*.
+1. **Errors** — unhandled route errors and failures your code can't recover from. Each becomes a grouped, alertable _issue_.
 2. **Logs** — recoverable failures and narrative events (a model attempt failed and the agent moved on, a retry, a fallback). Structured, searchable, linked to the trace — and they don't pollute the issue stream.
 3. **Traces** — the request's span tree: the incoming request, outbound fetches, and (for agents) the full model/tool call hierarchy with token usage.
 
@@ -18,12 +18,12 @@ All three carry the same trace ID, so from an error you can pivot to the logs an
 
 ### Environment variables
 
-| Variable | Purpose |
-| --- | --- |
-| `SENTRY_DSN` | Project DSN; keep it configurable through the deployment environment. |
-| `SENTRY_RELEASE` | Optional release identifier such as a commit SHA — unlocks regression detection. |
+| Variable                    | Purpose                                                                                                                        |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `SENTRY_DSN`                | Project DSN; keep it configurable through the deployment environment.                                                          |
+| `SENTRY_RELEASE`            | Optional release identifier such as a commit SHA — unlocks regression detection.                                               |
 | `SENTRY_TRACES_SAMPLE_RATE` | Trace sample rate, default `1`. Agents are low-throughput and every trace is interesting; lower it for high-volume plain HTTP. |
-| `PRODUCTION_BRANCH` | Your default branch's name, so it reports as environment `production` (see below). |
+| `PRODUCTION_BRANCH`         | Your default branch's name, so it reports as environment `production` (see below).                                             |
 
 ### 1. Initialize before anything else
 
@@ -46,7 +46,8 @@ Sentry.init({
   ],
   release: process.env.SENTRY_RELEASE,
   environment:
-    process.env.NEON_BRANCH && process.env.NEON_BRANCH !== process.env.PRODUCTION_BRANCH
+    process.env.NEON_BRANCH &&
+    process.env.NEON_BRANCH !== process.env.PRODUCTION_BRANCH
       ? process.env.NEON_BRANCH
       : "production",
 });
@@ -61,23 +62,13 @@ export { Sentry };
 // src/index.ts
 import "./instrument"; // MUST be the first import, before the framework/agent
 import { Sentry } from "./instrument";
+import { attachDatabasePool } from "@neon/functions";
 import { Hono } from "hono";
 import { Pool } from "pg";
 
-const PG_ADMIN_SHUTDOWN = "57P01";
-const IDLE_DISCONNECT_CODES = new Set(["ECONNRESET", "EPIPE", "ETIMEDOUT", PG_ADMIN_SHUTDOWN]);
-
-function isIdleDisconnect(err: Error): boolean {
-  const code = "code" in err && typeof err.code === "string" ? err.code : undefined;
-  return (
-    (code !== undefined && IDLE_DISCONNECT_CODES.has(code)) ||
-    err.message === "Connection terminated unexpectedly"
-  );
-}
-
 const pool = new Pool({ connectionString: process.env.DATABASE_URL, max: 5 });
-pool.on("error", (err) => {
-  if (!isIdleDisconnect(err)) Sentry.captureException(err);
+attachDatabasePool(pool, {
+  onUnexpectedError: (err) => Sentry.captureException(err),
 });
 
 // ... rest of the function
@@ -89,7 +80,7 @@ pool.on("error", (err) => {
 - **The two integrations:** `vercelAIIntegration({ force: true })` because `neon deploy` bundles your code, which defeats the integration's module detection; `httpIntegration({ disableIncomingRequestSpans: true })` because the request root span comes from the middleware in step 3 (the runtime's internal server would otherwise add a duplicate with an unhelpful name).
 - **Environment:** `NEON_BRANCH` is injected on every branch — including the default — and holds the branch **name** (e.g. `main`, `preview/add-auth`). Because it's always present, don't use it as a boolean flag; compare it against your default branch's name (passed in as `PRODUCTION_BRANCH`) so the default branch reads as `production` and other branches tag by name. Pass `SENTRY_ENVIRONMENT` explicitly per deploy to override.
 - **Flush on shutdown:** the runtime sends `SIGTERM`/`SIGINT` before evicting an idle isolate; Sentry buffers logs and batches spans, so flush or the tail gets dropped.
-- **Idle `pg` pool errors:** node-postgres emits idle-client failures as `error` on the pool. With no listener that is an `uncaughtException`: the isolate dies, and expected idle drops become fatal issues. Expected idle drops (`ECONNRESET` / `EPIPE` / `ETIMEDOUT`, Postgres `57P01`, pg's `Connection terminated unexpectedly`) stay silent; anything else is `Sentry.captureException`. Don't `pool.end()` on SIGINT — Neon's pooler reclaims those connections. See [Connecting to Postgres](../SKILL.md#connecting-to-postgres).
+- **Idle `pg` pool errors:** call `attachDatabasePool(pool)` (or pass `onUnexpectedError: (err) => Sentry.captureException(err)` on the first call). Don't `pool.end()` on SIGINT — Neon's pooler reclaims those connections. See [Connecting to Postgres](../SKILL.md#connecting-to-postgres).
 
 ### 2. Provide the DSN as a deploy-time secret
 
@@ -116,7 +107,10 @@ app.use("*", (c, next) =>
         op: "http.server",
         name: `${c.req.method} ${c.req.path}`,
         forceTransaction: true,
-        attributes: { "http.request.method": c.req.method, "url.path": c.req.path },
+        attributes: {
+          "http.request.method": c.req.method,
+          "url.path": c.req.path,
+        },
       },
       async (span) => {
         await next();
@@ -146,7 +140,7 @@ Long-running agent workloads — the case Neon Functions are built for — typic
 Split by whether someone needs to act:
 
 - **`Sentry.captureException` — terminal, needs attention.** The agent exhausted every fallback; an invariant broke. These become issues, group, and alert.
-- **`Sentry.logger.*` — recoverable or narrative.** A model attempt failed and the agent moved on; an input couldn't be fetched; a milestone was reached. Structured log records, searchable by attribute and attached to the request's trace — the story you read *after* an issue fires.
+- **`Sentry.logger.*` — recoverable or narrative.** A model attempt failed and the agent moved on; an input couldn't be fetched; a milestone was reached. Structured log records, searchable by attribute and attached to the request's trace — the story you read _after_ an issue fires.
 
 A representative agent that tries several models in order:
 
@@ -195,7 +189,9 @@ const result = streamText({
   tools,
   experimental_telemetry: { isEnabled: true },
   onError: ({ error }) => {
-    Sentry.captureException(error, { tags: { component: "agent", phase: "chat-stream" } });
+    Sentry.captureException(error, {
+      tags: { component: "agent", phase: "chat-stream" },
+    });
   },
 });
 ```
@@ -213,7 +209,9 @@ const stream = result.textStream
     }),
   )
   .pipeThrough(new TextEncoderStream());
-return new Response(stream, { headers: { "content-type": "text/plain; charset=utf-8" } });
+return new Response(stream, {
+  headers: { "content-type": "text/plain; charset=utf-8" },
+});
 ```
 
 (Once the runtime's `waitUntil` is no longer a preview stub, `waitUntil(Sentry.flush(2000))` is the cleaner way to express this.)

--- a/skills/neon-functions/references/sentry.md
+++ b/skills/neon-functions/references/sentry.md
@@ -62,7 +62,24 @@ export { Sentry };
 import "./instrument"; // MUST be the first import, before the framework/agent
 import { Sentry } from "./instrument";
 import { Hono } from "hono";
+import { Pool } from "pg";
 // ... rest of the function
+
+const PG_ADMIN_SHUTDOWN = "57P01";
+const IDLE_DISCONNECT_CODES = new Set(["ECONNRESET", "EPIPE", "ETIMEDOUT", PG_ADMIN_SHUTDOWN]);
+
+function isIdleDisconnect(err: Error): boolean {
+  const code = "code" in err && typeof err.code === "string" ? err.code : undefined;
+  return (
+    (code !== undefined && IDLE_DISCONNECT_CODES.has(code)) ||
+    err.message === "Connection terminated unexpectedly"
+  );
+}
+
+const pool = new Pool({ connectionString: process.env.DATABASE_URL, max: 5 });
+pool.on("error", (err) => {
+  if (!isIdleDisconnect(err)) Sentry.captureException(err);
+});
 ```
 
 - **Gate `enabled` on the DSN.** Local dev (`neon dev`) and any branch where you haven't configured the secret then become a no-op — no init, no noise — without changing code.
@@ -71,6 +88,7 @@ import { Hono } from "hono";
 - **The two integrations:** `vercelAIIntegration({ force: true })` because `neon deploy` bundles your code, which defeats the integration's module detection; `httpIntegration({ disableIncomingRequestSpans: true })` because the request root span comes from the middleware in step 3 (the runtime's internal server would otherwise add a duplicate with an unhelpful name).
 - **Environment:** `NEON_BRANCH` is injected on every branch — including the default — and holds the branch **name** (e.g. `main`, `preview/add-auth`). Because it's always present, don't use it as a boolean flag; compare it against your default branch's name (passed in as `PRODUCTION_BRANCH`) so the default branch reads as `production` and other branches tag by name. Pass `SENTRY_ENVIRONMENT` explicitly per deploy to override.
 - **Flush on shutdown:** the runtime sends `SIGTERM`/`SIGINT` before evicting an idle isolate; Sentry buffers logs and batches spans, so flush or the tail gets dropped.
+- **Idle `pg` pool errors:** node-postgres emits idle-client failures as `error` on the pool. With no listener that is an `uncaughtException` and the isolate exits before Sentry flushes. Expected idle drops (`ECONNRESET` / `EPIPE` / `ETIMEDOUT`, Postgres `57P01`, pg's `Connection terminated unexpectedly`) stay silent; anything else is `Sentry.captureException`. Don't `pool.end()` on SIGINT — Neon's pooler reclaims those connections. See [Connecting to Postgres](../SKILL.md#connecting-to-postgres).
 
 ### 2. Provide the DSN as a deploy-time secret
 

--- a/skills/neon-functions/references/sentry.md
+++ b/skills/neon-functions/references/sentry.md
@@ -63,7 +63,6 @@ import "./instrument"; // MUST be the first import, before the framework/agent
 import { Sentry } from "./instrument";
 import { Hono } from "hono";
 import { Pool } from "pg";
-// ... rest of the function
 
 const PG_ADMIN_SHUTDOWN = "57P01";
 const IDLE_DISCONNECT_CODES = new Set(["ECONNRESET", "EPIPE", "ETIMEDOUT", PG_ADMIN_SHUTDOWN]);
@@ -80,6 +79,8 @@ const pool = new Pool({ connectionString: process.env.DATABASE_URL, max: 5 });
 pool.on("error", (err) => {
   if (!isIdleDisconnect(err)) Sentry.captureException(err);
 });
+
+// ... rest of the function
 ```
 
 - **Gate `enabled` on the DSN.** Local dev (`neon dev`) and any branch where you haven't configured the secret then become a no-op — no init, no noise — without changing code.
@@ -88,7 +89,7 @@ pool.on("error", (err) => {
 - **The two integrations:** `vercelAIIntegration({ force: true })` because `neon deploy` bundles your code, which defeats the integration's module detection; `httpIntegration({ disableIncomingRequestSpans: true })` because the request root span comes from the middleware in step 3 (the runtime's internal server would otherwise add a duplicate with an unhelpful name).
 - **Environment:** `NEON_BRANCH` is injected on every branch — including the default — and holds the branch **name** (e.g. `main`, `preview/add-auth`). Because it's always present, don't use it as a boolean flag; compare it against your default branch's name (passed in as `PRODUCTION_BRANCH`) so the default branch reads as `production` and other branches tag by name. Pass `SENTRY_ENVIRONMENT` explicitly per deploy to override.
 - **Flush on shutdown:** the runtime sends `SIGTERM`/`SIGINT` before evicting an idle isolate; Sentry buffers logs and batches spans, so flush or the tail gets dropped.
-- **Idle `pg` pool errors:** node-postgres emits idle-client failures as `error` on the pool. With no listener that is an `uncaughtException` and the isolate exits before Sentry flushes. Expected idle drops (`ECONNRESET` / `EPIPE` / `ETIMEDOUT`, Postgres `57P01`, pg's `Connection terminated unexpectedly`) stay silent; anything else is `Sentry.captureException`. Don't `pool.end()` on SIGINT — Neon's pooler reclaims those connections. See [Connecting to Postgres](../SKILL.md#connecting-to-postgres).
+- **Idle `pg` pool errors:** node-postgres emits idle-client failures as `error` on the pool. With no listener that is an `uncaughtException`: the isolate dies, and expected idle drops become fatal issues. Expected idle drops (`ECONNRESET` / `EPIPE` / `ETIMEDOUT`, Postgres `57P01`, pg's `Connection terminated unexpectedly`) stay silent; anything else is `Sentry.captureException`. Don't `pool.end()` on SIGINT — Neon's pooler reclaims those connections. See [Connecting to Postgres](../SKILL.md#connecting-to-postgres).
 
 ### 2. Provide the DSN as a deploy-time secret
 

--- a/skills/neon-functions/references/sse.md
+++ b/skills/neon-functions/references/sse.md
@@ -78,9 +78,23 @@ The fan-out rule is identical to WebSockets ([Keeping clients in sync across iso
 ```typescript
 import { Pool, Client } from "pg";
 
+const PG_ADMIN_SHUTDOWN = "57P01";
+const IDLE_DISCONNECT_CODES = new Set(["ECONNRESET", "EPIPE", "ETIMEDOUT", PG_ADMIN_SHUTDOWN]);
+
+function isIdleDisconnect(err: Error): boolean {
+  const code = "code" in err && typeof err.code === "string" ? err.code : undefined;
+  return (
+    (code !== undefined && IDLE_DISCONNECT_CODES.has(code)) ||
+    err.message === "Connection terminated unexpectedly"
+  );
+}
+
 const encoder = new TextEncoder();
 const clients = new Set<ReadableStreamDefaultController<Uint8Array>>();
 const pool = new Pool({ connectionString: process.env.DATABASE_URL, max: 5 });
+pool.on("error", (err) => {
+  if (!isIdleDisconnect(err)) console.error(err);
+});
 const CHANNEL = "events";
 
 // One dedicated DIRECT connection per isolate to receive events (LISTEN needs a

--- a/skills/neon-functions/references/sse.md
+++ b/skills/neon-functions/references/sse.md
@@ -139,7 +139,7 @@ Send `data:` with no `event:` field to deliver the default `message` event, whic
 
 ```typescript
 const source = new EventSource(`${FUNCTION_URL}/events`); // GET only
-source.onmessage = (e) => console.log("update", e.data); // default "message" events
+source.onmessage = (e) => console.log("update", e.data);
 source.onerror = () => {
   /* EventSource auto-reconnects; nothing to do */
 };

--- a/skills/neon-functions/references/sse.md
+++ b/skills/neon-functions/references/sse.md
@@ -90,6 +90,7 @@ const CHANNEL = "events";
 
 // One dedicated DIRECT connection per isolate to receive events (LISTEN needs a
 // real session — use DATABASE_URL_UNPOOLED, not the pooled URL).
+// Don't call attachDatabasePool here: it would silence the idle drop that killed the feed.
 // An error listener keeps the isolate alive; the feed stays down until the isolate restarts.
 const listener = new Client({
   connectionString: process.env.DATABASE_URL_UNPOOLED,

--- a/skills/neon-functions/references/sse.md
+++ b/skills/neon-functions/references/sse.md
@@ -100,6 +100,9 @@ const CHANNEL = "events";
 // One dedicated DIRECT connection per isolate to receive events (LISTEN needs a
 // real session — use DATABASE_URL_UNPOOLED, not the pooled URL).
 const listener = new Client({ connectionString: process.env.DATABASE_URL_UNPOOLED });
+listener.on("error", (err) => {
+  if (!isIdleDisconnect(err)) console.error(err);
+});
 listener.connect().then(() => listener.query(`LISTEN ${CHANNEL}`));
 listener.on("notification", (msg) => {
   if (!msg.payload) return;

--- a/skills/neon-functions/references/sse.md
+++ b/skills/neon-functions/references/sse.md
@@ -99,6 +99,7 @@ const CHANNEL = "events";
 
 // One dedicated DIRECT connection per isolate to receive events (LISTEN needs a
 // real session — use DATABASE_URL_UNPOOLED, not the pooled URL).
+// An error listener keeps the isolate alive; the feed stays down until the isolate restarts.
 const listener = new Client({ connectionString: process.env.DATABASE_URL_UNPOOLED });
 listener.on("error", (err) => {
   if (!isIdleDisconnect(err)) console.error(err);

--- a/skills/neon-functions/references/sse.md
+++ b/skills/neon-functions/references/sse.md
@@ -64,7 +64,10 @@ app.get("/events", (c) => {
     },
   });
   return new Response(stream, {
-    headers: { "Content-Type": "text/event-stream", "Cache-Control": "no-cache, no-transform" },
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache, no-transform",
+    },
   });
 });
 
@@ -76,33 +79,23 @@ export default app;
 The fan-out rule is identical to WebSockets ([Keeping clients in sync across isolates](../SKILL.md#keeping-clients-in-sync-across-isolates-do-not-skip-this)): each isolate keeps its **own** set of open streams, so broadcasting in-process only reaches the clients on that isolate. Hold a `Set` of stream controllers and pick a strategy there — **poll Postgres** by default (keeps Scale to Zero), or `LISTEN`/`NOTIFY` (shown below) for lowest latency on always-on compute. Keep the source-of-truth state in Postgres — module state doesn't survive eviction.
 
 ```typescript
+import { attachDatabasePool } from "@neon/functions";
 import { Pool, Client } from "pg";
-
-const PG_ADMIN_SHUTDOWN = "57P01";
-const IDLE_DISCONNECT_CODES = new Set(["ECONNRESET", "EPIPE", "ETIMEDOUT", PG_ADMIN_SHUTDOWN]);
-
-function isIdleDisconnect(err: Error): boolean {
-  const code = "code" in err && typeof err.code === "string" ? err.code : undefined;
-  return (
-    (code !== undefined && IDLE_DISCONNECT_CODES.has(code)) ||
-    err.message === "Connection terminated unexpectedly"
-  );
-}
 
 const encoder = new TextEncoder();
 const clients = new Set<ReadableStreamDefaultController<Uint8Array>>();
 const pool = new Pool({ connectionString: process.env.DATABASE_URL, max: 5 });
-pool.on("error", (err) => {
-  if (!isIdleDisconnect(err)) console.error(err);
-});
+attachDatabasePool(pool);
 const CHANNEL = "events";
 
 // One dedicated DIRECT connection per isolate to receive events (LISTEN needs a
 // real session — use DATABASE_URL_UNPOOLED, not the pooled URL).
 // An error listener keeps the isolate alive; the feed stays down until the isolate restarts.
-const listener = new Client({ connectionString: process.env.DATABASE_URL_UNPOOLED });
+const listener = new Client({
+  connectionString: process.env.DATABASE_URL_UNPOOLED,
+});
 listener.on("error", (err) => {
-  if (!isIdleDisconnect(err)) console.error(err);
+  console.error(err);
 });
 listener.connect().then(() => listener.query(`LISTEN ${CHANNEL}`));
 listener.on("notification", (msg) => {
@@ -119,7 +112,10 @@ listener.on("notification", (msg) => {
 
 // Anywhere you mutate state, NOTIFY so every isolate pushes to its own streams.
 function publish(payload: unknown) {
-  return pool.query("SELECT pg_notify($1, $2)", [CHANNEL, JSON.stringify(payload)]);
+  return pool.query("SELECT pg_notify($1, $2)", [
+    CHANNEL,
+    JSON.stringify(payload),
+  ]);
 }
 ```
 
@@ -143,8 +139,10 @@ Send `data:` with no `event:` field to deliver the default `message` event, whic
 
 ```typescript
 const source = new EventSource(`${FUNCTION_URL}/events`); // GET only
-source.onmessage = (e) => console.log("update", e.data);  // default "message" events
-source.onerror = () => {/* EventSource auto-reconnects; nothing to do */};
+source.onmessage = (e) => console.log("update", e.data); // default "message" events
+source.onerror = () => {
+  /* EventSource auto-reconnects; nothing to do */
+};
 // source.close() to stop.
 ```
 


### PR DESCRIPTION
## Problem

Agents that follow `neon-functions` copy `new Pool(...)` at module scope and stop. node-postgres emits an idle-client failure as `error` on the pool. With no listener that is an `uncaughtException`, and Node exits the isolate.

In-flight work on that isolate dies. The next request is a cold start.

The skill should tell agents to call `attachDatabasePool` after `new Pool`. It should not tell them to copy the idle-disconnect classifier that helper already implements.

## Diagnosis

`@neon/functions` 0.8.0 already exports `attachDatabasePool`. The pool has discarded the dead client; the next checkout opens a replacement. The listener only has to keep Node from treating the event as fatal.

Expected idle disconnects (`ECONNRESET`, `EPIPE`, `ETIMEDOUT`, Postgres `57P01`, node-postgres's `Connection terminated unexpectedly`) are silent. Anything else is `console.error`, or `onUnexpectedError` if that option is passed on the first call. The first call wins. A later call that passes `onUnexpectedError` is ignored and warns. The helper does not close the pool.

`attachDatabasePool` duck-types `{ on("error") }`:

```typescript
export type DatabasePool = {
  on(event: "error", listener: (err: Error) => void): unknown;
};
```

A `pg.Client` typechecks. The LISTEN snippets still do not call it. An idle drop on the LISTEN connection is the feed dying, and the helper would swallow the codes that report that. The snippets attach `listener.on("error", ...)` so the isolate stays up, and they say the feed stays down until the isolate restarts.

## The user-facing interface

Default, after every `new Pool` in the skill:

```typescript
import { attachDatabasePool } from "@neon/functions";
import { Pool } from "pg";

const pool = new Pool({ connectionString: process.env.DATABASE_URL, max: 5 });
attachDatabasePool(pool);
```

When unexpected pool errors should go to Sentry, pass `onUnexpectedError` on that first call instead:

```typescript
import { attachDatabasePool } from "@neon/functions";
import { Pool } from "pg";
import { Sentry } from "./instrument";

const pool = new Pool({ connectionString: process.env.DATABASE_URL, max: 5 });
attachDatabasePool(pool, {
  onUnexpectedError: (err) => Sentry.captureException(err),
});
```

Requires `@neon/functions` ≥ 0.8.0.

LISTEN still uses a dedicated `Client` and a hand-written listener. The comments in the snippet are the rule:

```typescript
// Don't call attachDatabasePool here: it would silence the idle drop that killed the feed.
// An error listener keeps the isolate alive; the feed stays down until the isolate restarts.
const listener = new Client({
  connectionString: process.env.DATABASE_URL_UNPOOLED,
});
listener.on("error", (err) => {
  console.error(err);
});
```

Existing `@neon/functions` callers are unchanged. This repo only updates the skill.

## Also in here

- `plugins/neon-postgres/skills/neon-functions/` is a committed copy of `skills/neon-functions/`. `sync-plugin-skills.mjs --check` requires both trees to match.
- Prettier reflow in nearby snippets (JWT handler, WebSocket echo, SSE headers, Sentry tables, EventSource).

## Verification

From this worktree (`fix/pg-idle-pool-error` vs `origin/main`):

- `npm run validate:plugin-skills` — Plugin skills are in sync.
- `npm run validate:skills` — `skills/neon-functions` valid.
- `npm run validate:references` — reference graph OK for all 8 skills.
- `npm view @neon/functions@0.8.0` — published; the package description names `attachDatabasePool`.
- Read `packages/functions/src/lib/attach-database-pool.ts` on `neondatabase/neon-pkgs` `main`. `DatabasePool` is `{ on("error") }`. Idle codes match the skill text.

Not verified: a live Neon Function isolate dying without the listener, or staying up with it. This repo has no runtime tests for skill snippets.

## For your attention

- The LISTEN snippet does not reconnect. After an idle drop the isolate stays up and the feed stays down until the isolate restarts.
- Agents on `@neon/functions` < 0.8.0 will copy a call that does not exist until they upgrade.
- No changeset. This is skill markdown, not a published package API change in this repo.
