### PR TITLE
Add Pi as an install channel and stage the npm package fields

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,22 @@ Rules to keep in mind when touching these files:
 
 `npm run validate:agent-plugin` (part of `validate:ci`) enforces the manifest, MCP, and skill-discovery rules above. The last two bullets are packaging conventions rather than checked rules, though `validate:versions` does hold `kimi.plugin.json` to the version in `package.json` like every other manifest.
 
+## Pi, and the npm fields that are staged for it
+
+The [Pi coding agent](https://pi.dev) loads this repo through the `pi` block in [`package.json`](package.json) — `"pi": { "skills": ["./skills"] }` (see the [Pi package docs](https://github.com/earendil-works/pi/tree/main/packages/coding-agent/docs/packages.md)). Pi would auto-discover a top-level `skills/` by convention even without the block, but the explicit path is self-documenting and matches how every other channel here names its skills source.
+
+Like the root Agent Plugins v1 package, Pi reads `skills/` **directly** — no vendoring, no sync step (contrast the `plugins/` copies). So a new skill under `skills/` becomes a Pi skill automatically; nothing else to touch.
+
+A Pi package declares extensions, skills, prompt templates, and themes — not MCP servers — and Pi ships no built-in MCP by design, leaving it to an extension that reads its own config. So a Pi install carries the skills alone, unlike the Claude, Cursor, and Kimi packaging that declares the Neon MCP Server.
+
+**The README advertises the git install only.** `@neondatabase/agent-skills` is not on npm and nothing here publishes it, so `pi install npm:` would fail today. Three more fields in `package.json` are nonetheless in place, so publishing is a decision rather than a project:
+
+- `keywords` includes `"pi-package"` — the tag the [pi.dev/packages](https://pi.dev/packages) gallery crawls npm for. A git install works but never appears in the gallery, so this is what a publish buys. Keep it in mind if you ever reformat `keywords`.
+- `files` narrows the tarball to `skills/`, `plugin.json`, and `mcp.json` (npm always adds `package.json`, `README.md`, and `LICENSE`). Without it a publish would ship the whole tree — `evals/`, `.github/`, `scripts/`, everything.
+- `publishConfig.access` is `public`, because npm defaults a **scoped** package to a restricted (paid) publish and rejects it.
+
+None of these carries a version, so `sync-versions.mjs` neither reads nor writes them, and no validator enforces them. What's still missing is the release path: Neon publishes its npm packages from a private mirror rather than from the source repo, so wiring that up — and then documenting the npm install — is a follow-up.
+
 ## Downstream Marketplaces — Keep in Sync
 
 This repo (`skills/`) is the source of truth. The Neon skills are also published as plugins in external marketplaces that **vendor their own copies** of the skill files, so changes here do **not** propagate automatically. Whenever you add or change a skill, open a PR in each downstream marketplace to mirror it:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,10 +4,11 @@ Thanks for contributing to the Neon Agent Skills!
 
 ## Source of truth
 
-The top-level `skills/` directory is the source of truth. It is consumed three different ways:
+The top-level `skills/` directory is the source of truth. It is consumed four different ways:
 
 - The root [`plugin.json`](plugin.json) and [`mcp.json`](mcp.json) make the repository root a portable [Agent Plugins v1](https://agent-plugins.org/specification) package that reads `skills/` in place. No vendoring, no sync step.
 - The root [`kimi.plugin.json`](kimi.plugin.json) makes the repository installable as a Kimi Code plugin, also reading `skills/` in place. It declares the Neon MCP Server inline, because Kimi does not read the root `mcp.json`.
+- The `pi` block in [`package.json`](package.json) points [Pi](https://pi.dev) at `skills/`, also in place. Pi installs this repo from git, so it tracks `main` like the others.
 - Plugin folders under `plugins/` ship **real copies** of the skill directories they expose (not symlinks — Cursor and Claude silently drop symlinks that escape the plugin root when a plugin is installed from git).
 
 Which skills each plugin vendors is declared in the `PLUGIN_SKILLS` map in [`scripts/sync-plugin-skills.mjs`](scripts/sync-plugin-skills.mjs). A value of `"*"` means "all skills under `skills/`", so new skills are vendored automatically without editing the map; you can also list specific skill names instead. To regenerate the copies after editing a skill or the map:

--- a/README.md
+++ b/README.md
@@ -115,6 +115,14 @@ Kimi Code CLI reads its own manifest at [`kimi.plugin.json`](kimi.plugin.json), 
 
 Plugin changes apply to new sessions, so run `/new` afterward.
 
+### Pi
+
+You can also install the skills in [Pi](https://pi.dev), straight from this repo:
+
+```bash
+pi install git:github.com/neondatabase/agent-skills
+```
+
 ## Usage
 
 Example prompts:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@neondatabase/agent-skills",
   "version": "1.1.2",
-  "description": "A collection of Agent Skills for Neon",
+  "description": "Agent Skills for Neon: Lakebase Postgres, branching, Object Storage, Functions, and the AI Gateway",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -17,8 +17,22 @@
     "serverless",
     "agent-skills",
     "claude-code",
-    "mcp"
+    "mcp",
+    "pi-package"
   ],
+  "files": [
+    "skills/",
+    "plugin.json",
+    "mcp.json"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "pi": {
+    "skills": [
+      "./skills"
+    ]
+  },
   "scripts": {
     "prepare": "git config core.hooksPath .githooks || true",
     "fmt": "prettier --write .",


### PR DESCRIPTION
## Summary

- Adds [Pi](https://pi.dev) as an install channel. Pi reads the top-level `skills/` directly through a `pi` block in `package.json`, so it needs no vendoring and no sync step, exactly like the root Agent Plugins v1 package.
- The README documents the **git** install only. `@neondatabase/agent-skills` is not on npm, so `pi install npm:` would fail today.
- Stages the fields an npm publish would need without advertising it: the `pi-package` keyword (what the [pi.dev gallery](https://pi.dev/packages) crawls npm for), `files` to narrow the tarball to `skills/`, `plugin.json`, and `mcp.json`, and `publishConfig.access: public` because npm rejects a scoped package that hasn't opted in.
- Documents all of the above in `AGENTS.md`, and lists Pi as a fourth consumer of `skills/` in `CONTRIBUTING.md`.

Publishing to npm is a deliberate follow-up: Neon publishes its npm packages from a private mirror rather than from the source repo, so that release path has to be wired up before the npm install is worth documenting.

## Test plan

- [x] `npm run validate:ci` passes
- [x] `npm pack --dry-run` produces the intended 18-file tarball (`skills/`, `plugin.json`, `mcp.json`, plus npm's automatic `package.json`, `README.md`, `LICENSE`) — no `evals/`, `.github/`, or `scripts/`
- [x] New prose is Prettier-clean (pre-existing table-padding drift in `AGENTS.md` left alone)
- [ ] `pi install git:github.com/neondatabase/agent-skills` loads the skills