### PR TITLE
Run same-repo Validate on the Databricks protected runner group

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -40,13 +40,13 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   validate:
     name: Validate
-    # ubuntu-latest, not neondatabase-protected-runner-group: npm ci fetches
-    # from the public registry, which the protected group cannot reach.
-    runs-on: ubuntu-latest
+    # Fork PRs cannot mint OIDC tokens, and the protected group cannot reach npmjs.
+    runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || fromJSON('{"group":"neondatabase-protected-runner-group","labels":"linux-ubuntu-latest"}') }}
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.11.0
@@ -55,6 +55,24 @@ jobs:
 
       - name: Check out repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Setup JFrog CLI with OIDC
+        if: ${{ !github.event.pull_request.head.repo.fork }}
+        id: setup-jfrog
+        uses: jfrog/setup-jfrog-cli@279b1f629f43dd5bc658d8361ac4802a7ef8d2d5 # v4.9.1
+        env:
+          JF_URL: https://databricks.jfrog.io
+        with:
+          oidc-provider-name: github-actions
+
+      - name: Configure npm registry (Databricks JFrog mirror)
+        if: ${{ !github.event.pull_request.head.repo.fork }}
+        run: |
+          cat > ~/.npmrc <<EOF
+          registry=https://databricks.jfrog.io/artifactory/api/npm/db-npm/
+          //databricks.jfrog.io/artifactory/api/npm/db-npm/:_authToken=${{ steps.setup-jfrog.outputs.oidc-token }}
+          always-auth=true
+          EOF
 
       - name: Set up Node.js
         uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0


### PR DESCRIPTION
## Problem

`Validate` runs on `ubuntu-latest`, a GitHub-hosted runner, for every event. The workflow said why:

```yaml
    # ubuntu-latest, not neondatabase-protected-runner-group: npm ci fetches
    # from the public registry, which the protected group cannot reach.
    runs-on: ubuntu-latest
```

The protected runner group has no egress to the public internet, so a job that runs `npm ci` against `registry.npmjs.org` cannot run there. That kept the job on a hosted runner and its dependency fetch on the public registry.

## What changed the constraint

The registry is the constraint, and the job does not have to use the public one. `neondatabase/neon-pkgs` already installs packages on the protected group by minting a short-lived JFrog token over GitHub OIDC and writing an `~/.npmrc` that points npm at the Databricks mirror. The same three steps work here.

The residual case is a fork pull request. GitHub hands a fork-triggered workflow a read-only token and no OIDC identity, so nothing can mint a JFrog token there. Those runs stay on `ubuntu-latest` and the public registry.

## The workflow

`runs-on` is now an expression, and the two registry steps are skipped on fork pull requests:

```yaml
# .github/workflows/validate.yml
permissions:
  contents: read
  id-token: write

jobs:
  validate:
    name: Validate
    # Fork PRs cannot mint OIDC tokens, and the protected group cannot reach npmjs.
    runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || fromJSON('{"group":"neondatabase-protected-runner-group","labels":"linux-ubuntu-latest"}') }}
    steps:
      - name: Setup JFrog CLI with OIDC
        if: ${{ !github.event.pull_request.head.repo.fork }}
        id: setup-jfrog
        uses: jfrog/setup-jfrog-cli@279b1f629f43dd5bc658d8361ac4802a7ef8d2d5 # v4.9.1
        env:
          JF_URL: https://databricks.jfrog.io
        with:
          oidc-provider-name: github-actions

      - name: Configure npm registry (Databricks JFrog mirror)
        if: ${{ !github.event.pull_request.head.repo.fork }}
        run: |
          cat > ~/.npmrc <<EOF
          registry=https://databricks.jfrog.io/artifactory/api/npm/db-npm/
          //databricks.jfrog.io/artifactory/api/npm/db-npm/:_authToken=${{ steps.setup-jfrog.outputs.oidc-token }}
          always-auth=true
          EOF
```

`github.event.pull_request.head.repo.fork` is null on `push` and `workflow_dispatch`, so those events take the protected group with the mirror.

| Event | Runner | Registry |
|---|---|---|
| Pull request from a branch in this repo | protected group | Databricks JFrog mirror |
| Pull request from a fork | `ubuntu-latest` | public npm |
| Push to `main`, manual dispatch | protected group | Databricks JFrog mirror |

The rest of the job is unchanged: `harden-runner` in audit mode, SHA-pinned actions, `npm ci --ignore-scripts`, `npm run validate:ci`.

## Also in here

- `id-token: write` at the workflow level. `setup-jfrog-cli` needs it to request the OIDC token. `contents` stays `read`.
- `package-lock.json` is untouched and still resolves every package to `registry.npmjs.org`. npm's `replace-registry-host` default rewrites those hosts to the configured registry at install time, so the lockfile stays free of any mirror hostname and works on both runners.
- The repo's committed `.npmrc` only sets `save-exact`, so the generated `~/.npmrc` supplies the registry without a conflict.

## Verification

The workflow parses, and the job resolves to the values above:

```
runs-on: "${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || fromJSON('{\"group\":\"neondatabase-protected-runner-group\",\"labels\":\"linux-ubuntu-latest\"}') }}"
permissions: {"contents":"read","id-token":"write"}
```

`.github/workflows/validate.yml` is in the workflow's own `paths` filter, so the check on this pull request runs the changed job. This branch lives in the repo, which makes that run the same-repo path: protected group, OIDC, mirror install, `validate:ci`.

Not verified: the fork path. No fork pull request exists to exercise it, and it cannot be triggered from a branch in this repo. Opening a pull request from a fork of this repo is the only way to confirm it lands on `ubuntu-latest` and skips both registry steps.

## For your attention

- **A same-repo run now depends on the JFrog mirror and the OIDC provider.** If the mirror is unreachable or the `github-actions` provider is not configured for this repo, `Validate` fails where it previously did not. Reverting `runs-on` to `ubuntu-latest` restores the old behaviour on its own; the two `if:`-guarded steps become no-ops.
- **Fork and same-repo pull requests now install from different registries.** A package present on one and absent from the other produces a check result that depends on where the branch lives.
- **The runner selection is one expression rather than two jobs.** A matrix or a second job would make the two paths separately readable at the cost of duplicating every step.