### PR TITLE
Document Claimable Neon expirations and neon deploy for Auth

### DIFF
--- a/plugins/neon-postgres/skills/neon/SKILL.md
+++ b/plugins/neon-postgres/skills/neon/SKILL.md
@@ -187,7 +187,7 @@ If the Getting Started account check found credentials, use them. If a command w
 
 If they cannot sign in or provide a key right now, ask before using Claimable Neon. Continue only after they say yes. That is a temporary workaround.
 
-If there is no Neon account yet, follow [references/claimable-neon.md](https://neon.com/docs/ai/skills/neon/references/claimable-neon.md). Do not run `neon init --agent` or `neon auth` on this path; those need a human Neon account. If `neon claim` is missing, the reference has the REST fallback. Unclaimed projects expire at `project_expires_at` (72 hours today). Claim codes expire in `expires_in` (15 minutes today). After claim, add Auth or the Data API with `neon.ts` and `neon deploy`.
+If there is no Neon account yet, follow [references/claimable-neon.md](https://neon.com/docs/ai/skills/neon/references/claimable-neon.md). Do not run `neon init --agent` or `neon auth` on this path; those need a human Neon account. If `neon claim` is missing, the reference has the REST fallback. Unclaimed projects expire at `project_expires_at` (72 hours today). Claim codes expire in `expires_in` (15 minutes today). Add Auth or the Data API with `neon.ts` and `neon deploy` before or after claim.
 
 Requests for neon.new, Claimable Postgres, claimable.neon.tech, instant Postgres, or a no-signup database are the same path.
 

--- a/plugins/neon-postgres/skills/neon/SKILL.md
+++ b/plugins/neon-postgres/skills/neon/SKILL.md
@@ -187,7 +187,7 @@ If the Getting Started account check found credentials, use them. If a command w
 
 If they cannot sign in or provide a key right now, ask before using Claimable Neon. Continue only after they say yes. That is a temporary workaround.
 
-If there is no Neon account yet, follow [references/claimable-neon.md](https://neon.com/docs/ai/skills/neon/references/claimable-neon.md). Do not run `neon init --agent` or `neon auth` on this path; those need a human Neon account. If `neon claim` is missing, the reference has the REST fallback.
+If there is no Neon account yet, follow [references/claimable-neon.md](https://neon.com/docs/ai/skills/neon/references/claimable-neon.md). Do not run `neon init --agent` or `neon auth` on this path; those need a human Neon account. If `neon claim` is missing, the reference has the REST fallback. Unclaimed projects expire at `project_expires_at` (72 hours today). Claim codes expire in `expires_in` (15 minutes today). After claim, add Auth or the Data API with `neon.ts` and `neon deploy`.
 
 Requests for neon.new, Claimable Postgres, claimable.neon.tech, instant Postgres, or a no-signup database are the same path.
 

--- a/plugins/neon-postgres/skills/neon/references/claimable-neon.md
+++ b/plugins/neon-postgres/skills/neon/references/claimable-neon.md
@@ -49,7 +49,7 @@ Continuing to Neon starts a transfer with a new 15-minute window and leaves the 
 
 When `reconciled` is true, the pre-claim `DATABASE_URL` no longer works. Auth and Data API URLs stay if they were granted. The human signs in with `neon auth`. Then the agent runs `neon link --agent` and `neon env pull` to write the new `DATABASE_URL`. `neon link --agent` discovers the project after that sign-in.
 
-You cannot add Auth or the Data API to the unclaimed project after registration. Request them at create, or add them after claim with `neon.ts` and `neon deploy`:
+Auth and the Data API stay off unless requested at create or enabled later. On the unclaimed project, `neon.ts` plus `neon deploy` enables them. After claim, the same config talks to Neon directly. An external JWKS is only accepted after claim. Data API with the default auth provider requires Auth:
 
 ```typescript
 import { defineConfig } from "@neon/config/v1";
@@ -63,8 +63,6 @@ export default defineConfig({
 ```bash
 neon deploy
 ```
-
-Data API with the default auth provider requires Auth. An external JWKS is the other option:
 
 ```typescript
 export default defineConfig({

--- a/plugins/neon-postgres/skills/neon/references/claimable-neon.md
+++ b/plugins/neon-postgres/skills/neon/references/claimable-neon.md
@@ -37,13 +37,45 @@ export default defineConfig({
 
 Before claim, Postgres is always granted; Auth and the Data API are granted when requested. Functions, Object Storage, and AI Gateway come back with `granted: false` and `reason: "requires_claim"`. The CLI prints those as `denied_capabilities`. Report what you were given. Do not retry or strip them.
 
-After create, report the `project_id`, `project_expires_at`, and any denied capabilities. Do not invent the window.
+After create, report the `project_id`, `project_expires_at`, and any denied capabilities. Do not invent the window. Unclaimed projects expire at `project_expires_at` (72 hours today). That clock is independent of the claim code.
 
 ## Claim
 
 Do not mint a claim URL until the human is ready. Opening the URL does not freeze access. Continuing to Neon starts the transfer and rotates `DATABASE_URL`. Existing access tokens are revoked. Auth and the Data API stay enabled when they were granted.
 
-When `reconciled` is true, the pre-claim `DATABASE_URL` no longer works. Auth and Data API URLs stay. The human signs in with `neon auth`. Then the agent runs `neon link --agent` and `neon env pull` to write the new `DATABASE_URL`. `neon link --agent` discovers the project after that sign-in.
+A claim code expires in `expires_in` seconds (15 minutes / 900 today). If the unused code expires, mint another: `neon claim accept --no-open` or `POST /v1/projects/{id}/claim`. Each mint cancels the previous unused code. You can mint several times; only the latest unused code works. Re-issue only while `project_expires_at` is still in the future.
+
+Continuing to Neon starts a transfer with a new 15-minute window and leaves the project key and database password revoked. If that window expires before the human accepts, mint again. Do not restore pre-claim `DATABASE_URL`.
+
+When `reconciled` is true, the pre-claim `DATABASE_URL` no longer works. Auth and Data API URLs stay if they were granted. The human signs in with `neon auth`. Then the agent runs `neon link --agent` and `neon env pull` to write the new `DATABASE_URL`. `neon link --agent` discovers the project after that sign-in.
+
+You cannot add Auth or the Data API to the unclaimed project after registration. Request them at create, or add them after claim with `neon.ts` and `neon deploy`:
+
+```typescript
+import { defineConfig } from "@neon/config/v1";
+
+export default defineConfig({
+  auth: true,
+  dataApi: true,
+});
+```
+
+```bash
+neon deploy
+```
+
+Data API with the default auth provider requires Auth. An external JWKS is the other option:
+
+```typescript
+export default defineConfig({
+  dataApi: {
+    authProvider: "external",
+    jwksUrl: "https://example.com/.well-known/jwks.json",
+  },
+});
+```
+
+`neon checkout` does not apply this to an existing branch. `neon deploy` (alias of `neon config apply`) does.
 
 ### With the CLI
 
@@ -62,9 +94,9 @@ neon claim delete --yes
 
 ### With REST
 
-An agent must not complete the claim. Do not `POST /v1/projects/{id}/claim` until the human is ready. The human opens `verification_uri_complete` and accepts the transfer. If the claim code expires, `POST /v1/projects/{id}/claim` again. The live claim response also includes `user_code` and `expires_in`. `auth.md` documents `verification_uri_complete` and the polling `interval`.
+An agent must not complete the claim. Do not `POST /v1/projects/{id}/claim` until the human is ready. The human opens `verification_uri_complete` and accepts the transfer. If the claim code expires, `POST /v1/projects/{id}/claim` again. Each POST replaces the unused previous code. If the human continued to Neon and that transfer expired, POST again for a new code. The live claim response also includes `user_code` and `expires_in`. `auth.md` documents `verification_uri_complete` and the polling `interval`.
 
-After the human continues to Neon, existing access tokens are revoked: re-exchange the identity assertion, then poll `GET /v1/projects/{id}/claim` with that token at the interval `auth.md` returns. `claim_in_progress` means keep polling with the post-redemption token, not the token from create. Report `verification_uri_complete`, `user_code`, and `expires_in`.
+After the human continues to Neon, existing access tokens are revoked: re-exchange the identity assertion, then poll `GET /v1/projects/{id}/claim` with that token at the interval `auth.md` returns. `claim_in_progress` on a new mint means the transfer window is still live: poll, do not mint. After that window expires, POST claim again. Report `verification_uri_complete`, `user_code`, and `expires_in`.
 
 When `error.code` is `capability_requires_claim`, preserve the denied capability and give the human a claim link instead of retrying or silently omitting it.
 

--- a/skills/neon/SKILL.md
+++ b/skills/neon/SKILL.md
@@ -187,7 +187,7 @@ If the Getting Started account check found credentials, use them. If a command w
 
 If they cannot sign in or provide a key right now, ask before using Claimable Neon. Continue only after they say yes. That is a temporary workaround.
 
-If there is no Neon account yet, follow [references/claimable-neon.md](https://neon.com/docs/ai/skills/neon/references/claimable-neon.md). Do not run `neon init --agent` or `neon auth` on this path; those need a human Neon account. If `neon claim` is missing, the reference has the REST fallback. Unclaimed projects expire at `project_expires_at` (72 hours today). Claim codes expire in `expires_in` (15 minutes today). After claim, add Auth or the Data API with `neon.ts` and `neon deploy`.
+If there is no Neon account yet, follow [references/claimable-neon.md](https://neon.com/docs/ai/skills/neon/references/claimable-neon.md). Do not run `neon init --agent` or `neon auth` on this path; those need a human Neon account. If `neon claim` is missing, the reference has the REST fallback. Unclaimed projects expire at `project_expires_at` (72 hours today). Claim codes expire in `expires_in` (15 minutes today). Add Auth or the Data API with `neon.ts` and `neon deploy` before or after claim.
 
 Requests for neon.new, Claimable Postgres, claimable.neon.tech, instant Postgres, or a no-signup database are the same path.
 

--- a/skills/neon/SKILL.md
+++ b/skills/neon/SKILL.md
@@ -187,7 +187,7 @@ If the Getting Started account check found credentials, use them. If a command w
 
 If they cannot sign in or provide a key right now, ask before using Claimable Neon. Continue only after they say yes. That is a temporary workaround.
 
-If there is no Neon account yet, follow [references/claimable-neon.md](https://neon.com/docs/ai/skills/neon/references/claimable-neon.md). Do not run `neon init --agent` or `neon auth` on this path; those need a human Neon account. If `neon claim` is missing, the reference has the REST fallback.
+If there is no Neon account yet, follow [references/claimable-neon.md](https://neon.com/docs/ai/skills/neon/references/claimable-neon.md). Do not run `neon init --agent` or `neon auth` on this path; those need a human Neon account. If `neon claim` is missing, the reference has the REST fallback. Unclaimed projects expire at `project_expires_at` (72 hours today). Claim codes expire in `expires_in` (15 minutes today). After claim, add Auth or the Data API with `neon.ts` and `neon deploy`.
 
 Requests for neon.new, Claimable Postgres, claimable.neon.tech, instant Postgres, or a no-signup database are the same path.
 

--- a/skills/neon/references/claimable-neon.md
+++ b/skills/neon/references/claimable-neon.md
@@ -49,7 +49,7 @@ Continuing to Neon starts a transfer with a new 15-minute window and leaves the 
 
 When `reconciled` is true, the pre-claim `DATABASE_URL` no longer works. Auth and Data API URLs stay if they were granted. The human signs in with `neon auth`. Then the agent runs `neon link --agent` and `neon env pull` to write the new `DATABASE_URL`. `neon link --agent` discovers the project after that sign-in.
 
-You cannot add Auth or the Data API to the unclaimed project after registration. Request them at create, or add them after claim with `neon.ts` and `neon deploy`:
+Auth and the Data API stay off unless requested at create or enabled later. On the unclaimed project, `neon.ts` plus `neon deploy` enables them. After claim, the same config talks to Neon directly. An external JWKS is only accepted after claim. Data API with the default auth provider requires Auth:
 
 ```typescript
 import { defineConfig } from "@neon/config/v1";
@@ -63,8 +63,6 @@ export default defineConfig({
 ```bash
 neon deploy
 ```
-
-Data API with the default auth provider requires Auth. An external JWKS is the other option:
 
 ```typescript
 export default defineConfig({

--- a/skills/neon/references/claimable-neon.md
+++ b/skills/neon/references/claimable-neon.md
@@ -37,13 +37,45 @@ export default defineConfig({
 
 Before claim, Postgres is always granted; Auth and the Data API are granted when requested. Functions, Object Storage, and AI Gateway come back with `granted: false` and `reason: "requires_claim"`. The CLI prints those as `denied_capabilities`. Report what you were given. Do not retry or strip them.
 
-After create, report the `project_id`, `project_expires_at`, and any denied capabilities. Do not invent the window.
+After create, report the `project_id`, `project_expires_at`, and any denied capabilities. Do not invent the window. Unclaimed projects expire at `project_expires_at` (72 hours today). That clock is independent of the claim code.
 
 ## Claim
 
 Do not mint a claim URL until the human is ready. Opening the URL does not freeze access. Continuing to Neon starts the transfer and rotates `DATABASE_URL`. Existing access tokens are revoked. Auth and the Data API stay enabled when they were granted.
 
-When `reconciled` is true, the pre-claim `DATABASE_URL` no longer works. Auth and Data API URLs stay. The human signs in with `neon auth`. Then the agent runs `neon link --agent` and `neon env pull` to write the new `DATABASE_URL`. `neon link --agent` discovers the project after that sign-in.
+A claim code expires in `expires_in` seconds (15 minutes / 900 today). If the unused code expires, mint another: `neon claim accept --no-open` or `POST /v1/projects/{id}/claim`. Each mint cancels the previous unused code. You can mint several times; only the latest unused code works. Re-issue only while `project_expires_at` is still in the future.
+
+Continuing to Neon starts a transfer with a new 15-minute window and leaves the project key and database password revoked. If that window expires before the human accepts, mint again. Do not restore pre-claim `DATABASE_URL`.
+
+When `reconciled` is true, the pre-claim `DATABASE_URL` no longer works. Auth and Data API URLs stay if they were granted. The human signs in with `neon auth`. Then the agent runs `neon link --agent` and `neon env pull` to write the new `DATABASE_URL`. `neon link --agent` discovers the project after that sign-in.
+
+You cannot add Auth or the Data API to the unclaimed project after registration. Request them at create, or add them after claim with `neon.ts` and `neon deploy`:
+
+```typescript
+import { defineConfig } from "@neon/config/v1";
+
+export default defineConfig({
+  auth: true,
+  dataApi: true,
+});
+```
+
+```bash
+neon deploy
+```
+
+Data API with the default auth provider requires Auth. An external JWKS is the other option:
+
+```typescript
+export default defineConfig({
+  dataApi: {
+    authProvider: "external",
+    jwksUrl: "https://example.com/.well-known/jwks.json",
+  },
+});
+```
+
+`neon checkout` does not apply this to an existing branch. `neon deploy` (alias of `neon config apply`) does.
 
 ### With the CLI
 
@@ -62,9 +94,9 @@ neon claim delete --yes
 
 ### With REST
 
-An agent must not complete the claim. Do not `POST /v1/projects/{id}/claim` until the human is ready. The human opens `verification_uri_complete` and accepts the transfer. If the claim code expires, `POST /v1/projects/{id}/claim` again. The live claim response also includes `user_code` and `expires_in`. `auth.md` documents `verification_uri_complete` and the polling `interval`.
+An agent must not complete the claim. Do not `POST /v1/projects/{id}/claim` until the human is ready. The human opens `verification_uri_complete` and accepts the transfer. If the claim code expires, `POST /v1/projects/{id}/claim` again. Each POST replaces the unused previous code. If the human continued to Neon and that transfer expired, POST again for a new code. The live claim response also includes `user_code` and `expires_in`. `auth.md` documents `verification_uri_complete` and the polling `interval`.
 
-After the human continues to Neon, existing access tokens are revoked: re-exchange the identity assertion, then poll `GET /v1/projects/{id}/claim` with that token at the interval `auth.md` returns. `claim_in_progress` means keep polling with the post-redemption token, not the token from create. Report `verification_uri_complete`, `user_code`, and `expires_in`.
+After the human continues to Neon, existing access tokens are revoked: re-exchange the identity assertion, then poll `GET /v1/projects/{id}/claim` with that token at the interval `auth.md` returns. `claim_in_progress` on a new mint means the transfer window is still live: poll, do not mint. After that window expires, POST claim again. Report `verification_uri_complete`, `user_code`, and `expires_in`.
 
 When `error.code` is `capability_requires_claim`, preserve the denied capability and give the human a claim link instead of retrying or silently omitting it.
 


### PR DESCRIPTION
## Problem

An agent that needs a Neon account while the user is away follows this skill into Claimable Neon. The skill told it to report `project_expires_at` and to mint a claim URL when the human is ready. It did not say those are two clocks, what to do when the claim code runs out, or that Auth and the Data API can be turned on after create.

That gap shows up as a dead claim link, or as an agent that refuses to add Auth because it thinks the unclaimed project is frozen.

## Diagnosis

Unclaimed project lifetime and claim-code lifetime are independent:

- The project dies at `project_expires_at` (72 hours today).
- The claim code dies in `expires_in` seconds (900 today).

Opening the claim URL does not freeze access. Continuing to Neon starts a transfer, starts a new 15-minute window, and revokes the project key and database password. The unused-code path already replaced the previous code. After that transfer starts, a new code is available only once the transfer window has expired and the project is still unclaimed.

Auth and the Data API stay off unless requested at create. They can be enabled later with `neon.ts` and `neon deploy` on the unclaimed project. After claim, the same config talks to Neon directly. An external JWKS is only accepted after claim. `neon checkout` does not apply this to an existing branch.

## The user-facing interface

Two clocks, reported from the fields the CLI and HTTP already return:

```text
project_expires_at   72 hours today
expires_in           900 seconds today
```

If the unused code expires, mint another. Only the latest unused code works. Re-issue only while `project_expires_at` is still in the future:

```bash
neon claim accept --no-open
```

```http
POST /v1/projects/{id}/claim
Authorization: Bearer <access_token>
```

After the human continues to Neon, `claim_in_progress` means the transfer window is still live: poll, do not mint. After that window expires, POST claim again. Do not restore pre-claim `DATABASE_URL`.

Add Auth or the Data API before or after claim:

```typescript
import { defineConfig } from "@neon/config/v1";

export default defineConfig({
  auth: true,
  dataApi: true,
});
```

```bash
neon deploy
```

Data API with the default auth provider requires Auth. An external JWKS is only accepted after claim. Existing callers that already request Auth and the Data API at create do not change.

## Also in here

`plugins/neon-postgres/` copies the same skill text. That is `npm run sync:plugins`, not a second edit.

## Verification

```bash
npm run validate:ci
```

Passed on this branch. No new tests. The protocol this skill describes is already in `https://neon.com/auth.md` and on `https://claimable.neon.tech`; this PR is the agent copy.

Not verified here: OpenAI, Grok, and JetBrains marketplace copies. Those are separate repos.

## For your attention

- Marketplace plugin copies stay stale until someone opens PRs there.
- neon.com's hosted skill is a website PR, not this one.
- This does not announce Claimable Neon. It documents the flow agents already hit.