### PR TITLE
Release 1.2.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Official Neon plugins for Claude Code",
-    "version": "1.1.2"
+    "version": "1.2.0"
   },
   "plugins": [
     {
       "name": "neon-postgres",
       "source": "./plugins/neon-postgres",
       "description": "Manage your Neon backend with the Neon agent skills and the Neon MCP Server: Lakebase Postgres, branching, Object Storage, Functions, and the AI Gateway",
-      "version": "1.1.2",
+      "version": "1.2.0",
       "category": "database",
       "tags": ["neon", "lakebase", "postgres", "serverless", "database", "mcp"]
     }

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Official Neon plugins for Cursor",
-    "version": "1.1.2",
+    "version": "1.2.0",
     "pluginRoot": "plugins"
   },
   "plugins": [

--- a/kimi.plugin.json
+++ b/kimi.plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "neon-postgres",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "Manage your Neon backend with the Neon agent skills and the Neon MCP Server: Lakebase Postgres, branching, Object Storage, Functions, and the AI Gateway",
   "homepage": "https://neon.com",
   "license": "Apache-2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@neon/skills",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@neon/skills",
-      "version": "1.1.2",
+      "version": "1.2.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "prettier": "3.9.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neon/skills",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "Agent Skills for Neon: Lakebase Postgres, branching, Object Storage, Functions, and the AI Gateway",
   "license": "Apache-2.0",
   "repository": {

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "neon-postgres",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "Manage your Neon backend with the Neon agent skills and the Neon MCP Server: Lakebase Postgres, branching, Object Storage, Functions, and the AI Gateway",
   "author": {
     "name": "Neon",

--- a/plugins/neon-postgres/.claude-plugin/plugin.json
+++ b/plugins/neon-postgres/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "neon",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "Manage your Neon backend with the Neon agent skills and the Neon MCP Server: Lakebase Postgres, branching, Object Storage, Functions, and the AI Gateway",
   "author": {
     "name": "Neon",

--- a/plugins/neon-postgres/.cursor-plugin/plugin.json
+++ b/plugins/neon-postgres/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "neon-postgres",
   "displayName": "Neon Postgres",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "Manage your Neon backend with the Neon agent skills and the Neon MCP Server: Lakebase Postgres, branching, Object Storage, Functions, and the AI Gateway",
   "author": {
     "name": "Neon",


### PR DESCRIPTION
## Summary
- Bump the package from 1.1.2 to 1.2.0 (minor, not patch).
- Sync the same version into the plugin and marketplace manifests.
- Minor is the right bump because Claimable Neon moved into the neon skill, `claimable-postgres` was removed, and Pi plus the npm install channel landed after 1.1.2.

## Test plan
- [ ] Confirm CI `validate:ci` passes (especially `validate:versions`).
- [ ] Confirm every version-bearing manifest shows `1.2.0`.