### PR TITLE
docs: add eu-central-1 to backend skill region availability

### DIFF
--- a/plugins/neon-postgres/skills/neon-ai-gateway/SKILL.md
+++ b/plugins/neon-postgres/skills/neon-ai-gateway/SKILL.md
@@ -27,7 +27,7 @@ npx skills add neondatabase/agent-skills --skill neon
 
 # Neon AI Gateway
 
-This is a public beta feature and only available in `us-east-2`.
+This is a public beta feature, currently available in `us-east-2` and `eu-central-1`.
 
 The Neon AI Gateway is the LLM inference layer built into your Neon branch: one API and one Neon credential give you access to frontier and open-source models from many providers (Anthropic, OpenAI, Google, Meta, and more), all hosted and powered by Databricks. The catalog shifts over time, so treat `/v1/models` and the [models.dev Neon page](https://models.dev/providers/neon) as the source of truth rather than a fixed provider list. Your existing OpenAI/Anthropic/Gemini SDK works by changing only the base URL.
 
@@ -55,7 +55,7 @@ If the user already has a deep, single-provider integration and no interest in N
 
 Check these preconditions before setting anything up:
 
-The AI Gateway is a public beta feature available in the `us-east-2` region. Foundation model access requires a paid Neon plan. Confirm the user's project is in `us-east-2`.
+The AI Gateway is a public beta feature currently available in `us-east-2` and `eu-central-1`. Foundation model access requires a paid Neon plan. Confirm the user's project is in one of these regions.
 
 ### Enabling the gateway: plan and model-catalog gating
 

--- a/plugins/neon-postgres/skills/neon-functions/SKILL.md
+++ b/plugins/neon-postgres/skills/neon-functions/SKILL.md
@@ -27,7 +27,7 @@ npx skills add neondatabase/agent-skills --skill neon
 
 # Neon Functions
 
-This is a public beta feature and only available in `us-east-2`.
+This is a public beta feature, currently available in `us-east-2` and `eu-central-1`.
 
 Neon Functions are long-running Node.js HTTP handlers deployed onto a Neon branch. Each function gets a public HTTPS URL, runs in the same region as your database, and — if the branch has Postgres — gets `DATABASE_URL` injected automatically. You deploy and manage them through the same Neon CLI, `neon.ts`, and API you already use.
 
@@ -43,7 +43,7 @@ Reach for Neon Functions when the workload is a request/response handler that be
 - **A backend that branches with your data.** Each branch runs its own version of the function at its own URL, against its own isolated database (and storage, and gateway) state. Preview deployments, CI, and dev environments each get a self-contained backend — deploying to a child never affects the parent.
 - **Webhooks, bots, and post-response work.** Webhook handlers that fan out into multiple DB writes, Discord/WebSocket bots, and fire-and-forget follow-ups via `waitUntil` (analytics, audit logs) all fit.
 
-If the workload is a pure static site, a cron/background job that needs its own lifecycle and cancellation, or something that must run outside `us-east-2` today, this isn't the right tool yet (see [Timeouts and Runtime Limits](#timeouts-and-runtime-limits) and [Availability](#availability)).
+If the workload is a pure static site, a cron/background job that needs its own lifecycle and cancellation, or something that must run outside the supported regions (`us-east-2`, `eu-central-1`) today, this isn't the right tool yet (see [Timeouts and Runtime Limits](#timeouts-and-runtime-limits) and [Availability](#availability)).
 
 ## What It Does
 
@@ -55,7 +55,7 @@ If the workload is a pure static site, a cron/background job that needs its own 
 
 ## Availability
 
-Check this precondition before setting anything up: Neon Functions is a public beta feature available in the `us-east-2` region. Confirm the user's Neon project is in `us-east-2`. Functions usage isn't billed during the public beta.
+Check this precondition before setting anything up: Neon Functions is a public beta feature currently available in `us-east-2` and `eu-central-1`. Confirm the user's Neon project is in one of these regions. Functions usage isn't billed during the public beta.
 
 ## Architecture: Where Functions Fit
 

--- a/plugins/neon-postgres/skills/neon-object-storage/SKILL.md
+++ b/plugins/neon-postgres/skills/neon-object-storage/SKILL.md
@@ -27,7 +27,7 @@ npx skills add neondatabase/agent-skills --skill neon
 
 # Neon Object Storage
 
-This is a public beta feature and only available in `us-east-2`.
+This is a public beta feature, currently available in `us-east-2` and `eu-central-1`.
 
 Neon Object Storage is S3-compatible object storage that branches with your projects: every branch gets its own isolated storage state, so files and database rows stay in sync across dev, preview, staging, and production.
 
@@ -53,7 +53,7 @@ If the files in question ship with the app itself — HTML, JS bundles, CSS, the
 
 ## Availability
 
-Check this precondition before setting anything up: Neon Object Storage is a public beta feature available in the `us-east-2` region. Confirm the user's Neon project is in `us-east-2` before proceeding.
+Check this precondition before setting anything up: Neon Object Storage is a public beta feature currently available in `us-east-2` and `eu-central-1`. Confirm the user's Neon project is in one of these regions before proceeding.
 
 ## Architecture: Where Object Storage Fits
 

--- a/plugins/neon-postgres/skills/neon/SKILL.md
+++ b/plugins/neon-postgres/skills/neon/SKILL.md
@@ -41,7 +41,7 @@ Neon bundles several backend primitives for building apps and agents that all br
 
 Object Storage, Functions, and AI Gateway are in public beta.
 
-Beta access features are only available on projects in the `us-east-2` region. Before guiding a user through any of these services, confirm they are working in `us-east-2`. If not, they will need to create a new project in that region.
+Beta access features are currently available on projects in `us-east-2` and `eu-central-1`. Before guiding a user through any of these services, confirm they are working in one of these regions. If not, they will need to create a new project in a supported region.
 
 ## Architecture: How to Use Neon
 
@@ -391,7 +391,7 @@ For reading env you _already_ have on disk (typed and validated against your `ne
 
 ## Observability
 
-Neon exposes branch-scoped logs. **Today they cover Neon Functions and Object Storage only.** Postgres computes and the AI Gateway are coming; until then, neither emits records. Logs are region-gated like the other beta services above. Only `us-east-2` is enabled today. A branch that can't serve logs at all answers `404` with `reason: telemetry_not_enabled` (the message says whether it's the wrong region or a branch not collecting telemetry yet), versus a `200` empty result when the branch is enabled but has no records in the window; an unknown branch answers `reason: branch_not_found`.
+Neon exposes branch-scoped logs. **Today they cover Neon Functions and Object Storage only.** Postgres computes and the AI Gateway are coming; until then, neither emits records. Logs are region-gated like the other beta services above. `us-east-2` and `eu-central-1` are enabled today. A branch that can't serve logs at all answers `404` with `reason: telemetry_not_enabled` (the message says whether it's the wrong region or a branch not collecting telemetry yet), versus a `200` empty result when the branch is enabled but has no records in the window; an unknown branch answers `reason: branch_not_found`.
 
 Use Neon CLI 3.1 or newer first. **Decide which branch you are querying.** Without `--branch`, the CLI uses the branch pinned in `.neon`, or the project's default branch when the workspace isn't linked. A deployed function or bucket usually lives on a different branch than the one checked out for development, so an empty result is more often the wrong branch than a missing log.
 

--- a/skills/neon-ai-gateway/SKILL.md
+++ b/skills/neon-ai-gateway/SKILL.md
@@ -27,7 +27,7 @@ npx skills add neondatabase/agent-skills --skill neon
 
 # Neon AI Gateway
 
-This is a public beta feature and only available in `us-east-2`.
+This is a public beta feature, currently available in `us-east-2` and `eu-central-1`.
 
 The Neon AI Gateway is the LLM inference layer built into your Neon branch: one API and one Neon credential give you access to frontier and open-source models from many providers (Anthropic, OpenAI, Google, Meta, and more), all hosted and powered by Databricks. The catalog shifts over time, so treat `/v1/models` and the [models.dev Neon page](https://models.dev/providers/neon) as the source of truth rather than a fixed provider list. Your existing OpenAI/Anthropic/Gemini SDK works by changing only the base URL.
 
@@ -55,7 +55,7 @@ If the user already has a deep, single-provider integration and no interest in N
 
 Check these preconditions before setting anything up:
 
-The AI Gateway is a public beta feature available in the `us-east-2` region. Foundation model access requires a paid Neon plan. Confirm the user's project is in `us-east-2`.
+The AI Gateway is a public beta feature currently available in `us-east-2` and `eu-central-1`. Foundation model access requires a paid Neon plan. Confirm the user's project is in one of these regions.
 
 ### Enabling the gateway: plan and model-catalog gating
 

--- a/skills/neon-functions/SKILL.md
+++ b/skills/neon-functions/SKILL.md
@@ -27,7 +27,7 @@ npx skills add neondatabase/agent-skills --skill neon
 
 # Neon Functions
 
-This is a public beta feature and only available in `us-east-2`.
+This is a public beta feature, currently available in `us-east-2` and `eu-central-1`.
 
 Neon Functions are long-running Node.js HTTP handlers deployed onto a Neon branch. Each function gets a public HTTPS URL, runs in the same region as your database, and — if the branch has Postgres — gets `DATABASE_URL` injected automatically. You deploy and manage them through the same Neon CLI, `neon.ts`, and API you already use.
 
@@ -43,7 +43,7 @@ Reach for Neon Functions when the workload is a request/response handler that be
 - **A backend that branches with your data.** Each branch runs its own version of the function at its own URL, against its own isolated database (and storage, and gateway) state. Preview deployments, CI, and dev environments each get a self-contained backend — deploying to a child never affects the parent.
 - **Webhooks, bots, and post-response work.** Webhook handlers that fan out into multiple DB writes, Discord/WebSocket bots, and fire-and-forget follow-ups via `waitUntil` (analytics, audit logs) all fit.
 
-If the workload is a pure static site, a cron/background job that needs its own lifecycle and cancellation, or something that must run outside `us-east-2` today, this isn't the right tool yet (see [Timeouts and Runtime Limits](#timeouts-and-runtime-limits) and [Availability](#availability)).
+If the workload is a pure static site, a cron/background job that needs its own lifecycle and cancellation, or something that must run outside the supported regions (`us-east-2`, `eu-central-1`) today, this isn't the right tool yet (see [Timeouts and Runtime Limits](#timeouts-and-runtime-limits) and [Availability](#availability)).
 
 ## What It Does
 
@@ -55,7 +55,7 @@ If the workload is a pure static site, a cron/background job that needs its own 
 
 ## Availability
 
-Check this precondition before setting anything up: Neon Functions is a public beta feature available in the `us-east-2` region. Confirm the user's Neon project is in `us-east-2`. Functions usage isn't billed during the public beta.
+Check this precondition before setting anything up: Neon Functions is a public beta feature currently available in `us-east-2` and `eu-central-1`. Confirm the user's Neon project is in one of these regions. Functions usage isn't billed during the public beta.
 
 ## Architecture: Where Functions Fit
 

--- a/skills/neon-object-storage/SKILL.md
+++ b/skills/neon-object-storage/SKILL.md
@@ -27,7 +27,7 @@ npx skills add neondatabase/agent-skills --skill neon
 
 # Neon Object Storage
 
-This is a public beta feature and only available in `us-east-2`.
+This is a public beta feature, currently available in `us-east-2` and `eu-central-1`.
 
 Neon Object Storage is S3-compatible object storage that branches with your projects: every branch gets its own isolated storage state, so files and database rows stay in sync across dev, preview, staging, and production.
 
@@ -53,7 +53,7 @@ If the files in question ship with the app itself — HTML, JS bundles, CSS, the
 
 ## Availability
 
-Check this precondition before setting anything up: Neon Object Storage is a public beta feature available in the `us-east-2` region. Confirm the user's Neon project is in `us-east-2` before proceeding.
+Check this precondition before setting anything up: Neon Object Storage is a public beta feature currently available in `us-east-2` and `eu-central-1`. Confirm the user's Neon project is in one of these regions before proceeding.
 
 ## Architecture: Where Object Storage Fits
 

--- a/skills/neon/SKILL.md
+++ b/skills/neon/SKILL.md
@@ -41,7 +41,7 @@ Neon bundles several backend primitives for building apps and agents that all br
 
 Object Storage, Functions, and AI Gateway are in public beta.
 
-Beta access features are only available on projects in the `us-east-2` region. Before guiding a user through any of these services, confirm they are working in `us-east-2`. If not, they will need to create a new project in that region.
+Beta access features are currently available on projects in `us-east-2` and `eu-central-1`. Before guiding a user through any of these services, confirm they are working in one of these regions. If not, they will need to create a new project in a supported region.
 
 ## Architecture: How to Use Neon
 
@@ -391,7 +391,7 @@ For reading env you _already_ have on disk (typed and validated against your `ne
 
 ## Observability
 
-Neon exposes branch-scoped logs. **Today they cover Neon Functions and Object Storage only.** Postgres computes and the AI Gateway are coming; until then, neither emits records. Logs are region-gated like the other beta services above. Only `us-east-2` is enabled today. A branch that can't serve logs at all answers `404` with `reason: telemetry_not_enabled` (the message says whether it's the wrong region or a branch not collecting telemetry yet), versus a `200` empty result when the branch is enabled but has no records in the window; an unknown branch answers `reason: branch_not_found`.
+Neon exposes branch-scoped logs. **Today they cover Neon Functions and Object Storage only.** Postgres computes and the AI Gateway are coming; until then, neither emits records. Logs are region-gated like the other beta services above. `us-east-2` and `eu-central-1` are enabled today. A branch that can't serve logs at all answers `404` with `reason: telemetry_not_enabled` (the message says whether it's the wrong region or a branch not collecting telemetry yet), versus a `200` empty result when the branch is enabled but has no records in the window; an unknown branch answers `reason: branch_not_found`.
 
 Use Neon CLI 3.1 or newer first. **Decide which branch you are querying.** Without `--branch`, the CLI uses the branch pinned in `.neon`, or the project's default branch when the workspace isn't linked. A deployed function or bucket usually lives on a different branch than the one checked out for development, so an empty result is more often the wrong branch than a missing log.
 


### PR DESCRIPTION
## Overview

The Neon backend beta services (Functions, Object Storage, AI Gateway, and branch logs) now run in eu-central-1 in addition to us-east-2. This updates the region availability notes and preconditions in the neon, neon-functions, neon-ai-gateway, and neon-object-storage skills so an agent points users at either supported region.

No version bump; releasing is a separate step.

Mirrors neondatabase/website#5712.

This pull request and its description were written by Isaac.
